### PR TITLE
Create FetchPullRequests Use Case

### DIFF
--- a/lib/domain/pull_request.rb
+++ b/lib/domain/pull_request.rb
@@ -1,0 +1,12 @@
+module Domain
+  class PullRequest
+    attr_reader :application_name, :title, :opened_at, :url
+
+    def initialize(application_name:, title:, opened_at:, url:)
+      @application_name = application_name
+      @title = title
+      @opened_at = opened_at
+      @url = url
+    end
+  end
+end

--- a/lib/loader.rb
+++ b/lib/loader.rb
@@ -1,1 +1,3 @@
+require_relative './domain/pull_request'
+
 require_relative './use_cases/fetch_pull_requests'

--- a/lib/loader.rb
+++ b/lib/loader.rb
@@ -1,0 +1,1 @@
+require_relative './use_cases/fetch_pull_requests'

--- a/lib/use_cases/fetch_pull_requests.rb
+++ b/lib/use_cases/fetch_pull_requests.rb
@@ -1,11 +1,15 @@
 module UseCases
   class FetchPullRequests
     def initialize(gateway:)
+      @gateway = gateway
     end
 
     def execute
-      []
+      gateway.execute
     end
+
+  private
+
+    attr_reader :gateway
   end
 end
-

--- a/lib/use_cases/fetch_pull_requests.rb
+++ b/lib/use_cases/fetch_pull_requests.rb
@@ -1,0 +1,11 @@
+module UseCases
+  class FetchPullRequests
+    def initialize(gateway:)
+    end
+
+    def execute
+      []
+    end
+  end
+end
+

--- a/spec/app_spec.rb
+++ b/spec/app_spec.rb
@@ -10,7 +10,7 @@ xdescribe GovukDependencies do
 
   before do
     stub_request(:get, 'https://api.github.com/search/issues?q=is:pr+user:alphagov+state:open+author:app/dependabot')
-      .to_return(body: File.read('spec/fixtures/pull_requests.json'), headers: {'Content-Type' => 'application/json'})
+      .to_return(body: File.read('spec/fixtures/pull_requests.json'), headers: { 'Content-Type' => 'application/json' })
   end
 
   it 'should show both applications with the number of open pull requests' do

--- a/spec/app_spec.rb
+++ b/spec/app_spec.rb
@@ -4,12 +4,18 @@ require_relative '../app'
 
 ENV['RACK_ENV'] = 'test'
 
-describe GovukDependencies do
+xdescribe GovukDependencies do
   include Rack::Test::Methods
   def app() described_class end
 
-  it "should allow accessing the home page" do
+  before do
+    stub_request(:get, 'https://api.github.com/search/issues?q=is:pr+user:alphagov+state:open+author:app/dependabot')
+      .to_return(body: File.read('spec/fixtures/pull_requests.json'), headers: {'Content-Type' => 'application/json'})
+  end
+
+  it 'should show both applications with the number of open pull requests' do
     get '/'
-    expect(last_response).to be_ok
+    expect(last_response.body).to include('frontend (1)')
+    expect(last_response.body).to include('publisher (2)')
   end
 end

--- a/spec/fixtures/pull_requests.json
+++ b/spec/fixtures/pull_requests.json
@@ -1,0 +1,184 @@
+{
+  "total_count": 3,
+  "incomplete_results": false,
+  "items": [
+    {
+      "url": "https://api.github.com/repos/alphagov/publisher/issues/761",
+      "repository_url": "https://api.github.com/repos/alphagov/publisher",
+      "labels_url": "https://api.github.com/repos/alphagov/publisher/issues/761/labels{/name}",
+      "comments_url": "https://api.github.com/repos/alphagov/publisher/issues/761/comments",
+      "events_url": "https://api.github.com/repos/alphagov/publisher/issues/761/events",
+      "html_url": "https://github.com/alphagov/publisher/pull/761",
+      "id": 291111856,
+      "number": 761,
+      "title": "Bump gds-sso from 13.5.0 to 13.5.1",
+      "user": {
+        "login": "dependabot[bot]",
+        "id": 27856297,
+        "avatar_url": "https://avatars3.githubusercontent.com/in/2141?v=4",
+        "gravatar_id": "",
+        "url": "https://api.github.com/users/dependabot%5Bbot%5D",
+        "html_url": "https://github.com/apps/dependabot",
+        "followers_url": "https://api.github.com/users/dependabot%5Bbot%5D/followers",
+        "following_url": "https://api.github.com/users/dependabot%5Bbot%5D/following{/other_user}",
+        "gists_url": "https://api.github.com/users/dependabot%5Bbot%5D/gists{/gist_id}",
+        "starred_url": "https://api.github.com/users/dependabot%5Bbot%5D/starred{/owner}{/repo}",
+        "subscriptions_url": "https://api.github.com/users/dependabot%5Bbot%5D/subscriptions",
+        "organizations_url": "https://api.github.com/users/dependabot%5Bbot%5D/orgs",
+        "repos_url": "https://api.github.com/users/dependabot%5Bbot%5D/repos",
+        "events_url": "https://api.github.com/users/dependabot%5Bbot%5D/events{/privacy}",
+        "received_events_url": "https://api.github.com/users/dependabot%5Bbot%5D/received_events",
+        "type": "Bot",
+        "site_admin": false
+      },
+      "labels": [
+        {
+          "id": 779829793,
+          "url": "https://api.github.com/repos/alphagov/publisher/labels/dependencies",
+          "name": "dependencies",
+          "color": "0025ff",
+          "default": false
+        }
+      ],
+      "state": "closed",
+      "locked": false,
+      "assignee": null,
+      "assignees": [
+
+      ],
+      "milestone": null,
+      "comments": 0,
+      "created_at": "2018-01-24T07:41:46Z",
+      "updated_at": "2018-01-24T08:08:41Z",
+      "closed_at": "2018-01-24T08:08:27Z",
+      "author_association": "NONE",
+      "pull_request": {
+        "url": "https://api.github.com/repos/alphagov/publisher/pulls/761",
+        "html_url": "https://github.com/alphagov/publisher/pull/761",
+        "diff_url": "https://github.com/alphagov/publisher/pull/761.diff",
+        "patch_url": "https://github.com/alphagov/publisher/pull/761.patch"
+      },
+      "body": "Bumps [gds-sso](https://github.com/alphagov/gds-sso) from 13.5.0 to 13.5.1.\n- [Changelog](https://github.com/alphagov/gds-sso/blob/master/CHANGELOG.md)\n- [Commits](https://github.com/alphagov/gds-sso/compare/v13.5.0...v13.5.1)\n\n[![Dependabot compatibility score](https://api.dependabot.com/badges/ci_status?dependency-name=gds-sso&package-manager=bundler&previous-version=13.5.0&new-version=13.5.1)](https://dependabot.com/compatibility-score.html?dependency-name=gds-sso&package-manager=bundler&previous-version=13.5.0&new-version=13.5.1)\n\nDependabot will resolve any conflicts with this PR as long as you don't alter it yourself. You can also trigger a rebase manually by commenting `@dependabot rebase`.\n\nIf you'd like to skip this version, you can just close this PR. If you have any feedback just mention @dependabot in the comments below.",
+      "score": 1.0
+    },
+    {
+      "url": "https://api.github.com/repos/alphagov/frontend/issues/1146",
+      "repository_url": "https://api.github.com/repos/alphagov/frontend",
+      "labels_url": "https://api.github.com/repos/alphagov/frontend/issues/1146/labels{/name}",
+      "comments_url": "https://api.github.com/repos/alphagov/frontend/issues/1146/comments",
+      "events_url": "https://api.github.com/repos/alphagov/frontend/issues/1146/events",
+      "html_url": "https://github.com/alphagov/frontend/pull/1146",
+      "id": 291111666,
+      "number": 1146,
+      "title": "Bump gds-sso from 13.5.0 to 13.5.1",
+      "user": {
+        "login": "dependabot[bot]",
+        "id": 27856297,
+        "avatar_url": "https://avatars3.githubusercontent.com/in/2141?v=4",
+        "gravatar_id": "",
+        "url": "https://api.github.com/users/dependabot%5Bbot%5D",
+        "html_url": "https://github.com/apps/dependabot",
+        "followers_url": "https://api.github.com/users/dependabot%5Bbot%5D/followers",
+        "following_url": "https://api.github.com/users/dependabot%5Bbot%5D/following{/other_user}",
+        "gists_url": "https://api.github.com/users/dependabot%5Bbot%5D/gists{/gist_id}",
+        "starred_url": "https://api.github.com/users/dependabot%5Bbot%5D/starred{/owner}{/repo}",
+        "subscriptions_url": "https://api.github.com/users/dependabot%5Bbot%5D/subscriptions",
+        "organizations_url": "https://api.github.com/users/dependabot%5Bbot%5D/orgs",
+        "repos_url": "https://api.github.com/users/dependabot%5Bbot%5D/repos",
+        "events_url": "https://api.github.com/users/dependabot%5Bbot%5D/events{/privacy}",
+        "received_events_url": "https://api.github.com/users/dependabot%5Bbot%5D/received_events",
+        "type": "Bot",
+        "site_admin": false
+      },
+      "labels": [
+        {
+          "id": 775499521,
+          "url": "https://api.github.com/repos/alphagov/frontend/labels/dependencies",
+          "name": "dependencies",
+          "color": "0025ff",
+          "default": false
+        }
+      ],
+      "state": "closed",
+      "locked": false,
+      "assignee": null,
+      "assignees": [
+
+      ],
+      "milestone": null,
+      "comments": 0,
+      "created_at": "2018-01-24T07:40:57Z",
+      "updated_at": "2018-01-24T08:09:41Z",
+      "closed_at": "2018-01-24T08:09:18Z",
+      "author_association": "NONE",
+      "pull_request": {
+        "url": "https://api.github.com/repos/alphagov/frontend/pulls/1146",
+        "html_url": "https://github.com/alphagov/frontend/pull/1146",
+        "diff_url": "https://github.com/alphagov/frontend/pull/1146.diff",
+        "patch_url": "https://github.com/alphagov/frontend/pull/1146.patch"
+      },
+      "body": "Bumps [gds-sso](https://github.com/alphagov/gds-sso) from 13.5.0 to 13.5.1.\n- [Changelog](https://github.com/alphagov/gds-sso/blob/master/CHANGELOG.md)\n- [Commits](https://github.com/alphagov/gds-sso/compare/v13.5.0...v13.5.1)\n\n[![Dependabot compatibility score](https://api.dependabot.com/badges/ci_status?dependency-name=gds-sso&package-manager=bundler&previous-version=13.5.0&new-version=13.5.1)](https://dependabot.com/compatibility-score.html?dependency-name=gds-sso&package-manager=bundler&previous-version=13.5.0&new-version=13.5.1)\n\nDependabot will resolve any conflicts with this PR as long as you don't alter it yourself. You can also trigger a rebase manually by commenting `@dependabot rebase`.\n\nIf you'd like to skip this version, you can just close this PR. If you have any feedback just mention @dependabot in the comments below.",
+      "score": 1.0
+    },
+    {
+      "url": "https://api.github.com/repos/alphagov/publisher/issues/187",
+      "repository_url": "https://api.github.com/repos/alphagov/publisher",
+      "labels_url": "https://api.github.com/repos/alphagov/publisher/issues/187/labels{/name}",
+      "comments_url": "https://api.github.com/repos/alphagov/publisher/issues/187/comments",
+      "events_url": "https://api.github.com/repos/alphagov/publisher/issues/187/events",
+      "html_url": "https://github.com/alphagov/publisher/pull/187",
+      "id": 291111562,
+      "number": 187,
+      "title": "Bump gds-sso from 13.0.0 to 13.5.1",
+      "user": {
+        "login": "dependabot[bot]",
+        "id": 27856297,
+        "avatar_url": "https://avatars3.githubusercontent.com/in/2141?v=4",
+        "gravatar_id": "",
+        "url": "https://api.github.com/users/dependabot%5Bbot%5D",
+        "html_url": "https://github.com/apps/dependabot",
+        "followers_url": "https://api.github.com/users/dependabot%5Bbot%5D/followers",
+        "following_url": "https://api.github.com/users/dependabot%5Bbot%5D/following{/other_user}",
+        "gists_url": "https://api.github.com/users/dependabot%5Bbot%5D/gists{/gist_id}",
+        "starred_url": "https://api.github.com/users/dependabot%5Bbot%5D/starred{/owner}{/repo}",
+        "subscriptions_url": "https://api.github.com/users/dependabot%5Bbot%5D/subscriptions",
+        "organizations_url": "https://api.github.com/users/dependabot%5Bbot%5D/orgs",
+        "repos_url": "https://api.github.com/users/dependabot%5Bbot%5D/repos",
+        "events_url": "https://api.github.com/users/dependabot%5Bbot%5D/events{/privacy}",
+        "received_events_url": "https://api.github.com/users/dependabot%5Bbot%5D/received_events",
+        "type": "Bot",
+        "site_admin": false
+      },
+      "labels": [
+        {
+          "id": 781058033,
+          "url": "https://api.github.com/repos/alphagov/publisher/labels/dependencies",
+          "name": "dependencies",
+          "color": "0025ff",
+          "default": false
+        }
+      ],
+      "state": "closed",
+      "locked": false,
+      "assignee": null,
+      "assignees": [
+
+      ],
+      "milestone": null,
+      "comments": 0,
+      "created_at": "2018-01-24T07:40:24Z",
+      "updated_at": "2018-01-24T08:09:41Z",
+      "closed_at": "2018-01-24T08:09:27Z",
+      "author_association": "NONE",
+      "pull_request": {
+        "url": "https://api.github.com/repos/alphagov/publisher/pulls/187",
+        "html_url": "https://github.com/alphagov/publisher/pull/187",
+        "diff_url": "https://github.com/alphagov/publisher/pull/187.diff",
+        "patch_url": "https://github.com/alphagov/publisher/pull/187.patch"
+      },
+      "body": "Bumps [gds-sso](https://github.com/alphagov/gds-sso) from 13.0.0 to 13.5.1.\n- [Changelog](https://github.com/alphagov/gds-sso/blob/master/CHANGELOG.md)\n- [Commits](https://github.com/alphagov/gds-sso/compare/v13.0.0...v13.5.1)\n\n[![Dependabot compatibility score](https://api.dependabot.com/badges/ci_status?dependency-name=gds-sso&package-manager=bundler&previous-version=13.0.0&new-version=13.5.1)](https://dependabot.com/compatibility-score.html?dependency-name=gds-sso&package-manager=bundler&previous-version=13.0.0&new-version=13.5.1)\n\nDependabot will resolve any conflicts with this PR as long as you don't alter it yourself. You can also trigger a rebase manually by commenting `@dependabot rebase`.\n\nIf you'd like to skip this version, you can just close this PR. If you have any feedback just mention @dependabot in the comments below.",
+      "score": 1.0
+    }
+  ]
+}
+

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,4 +1,5 @@
 require 'webmock/rspec'
 require 'rspec'
+require_relative '../lib/loader'
 
 WebMock.disable_net_connect!(allow_localhost: true)

--- a/spec/use_cases/fetch_pull_requests_spec.rb
+++ b/spec/use_cases/fetch_pull_requests_spec.rb
@@ -1,0 +1,8 @@
+describe UseCases::FetchPullRequests do
+  it 'Returns an empty array given no pull requests' do
+    gateway = stub(execute: [])
+    result = described_class.new(gateway: gateway).execute
+    expect(result).to be_empty
+  end
+end
+

--- a/spec/use_cases/fetch_pull_requests_spec.rb
+++ b/spec/use_cases/fetch_pull_requests_spec.rb
@@ -1,8 +1,31 @@
+require 'date'
+
 describe UseCases::FetchPullRequests do
-  it 'Returns an empty array given no pull requests' do
-    gateway = stub(execute: [])
-    result = described_class.new(gateway: gateway).execute
-    expect(result).to be_empty
+  let(:gateway) { double(execute: pull_requests) }
+  let(:results) { described_class.new(gateway: gateway).execute }
+
+  context 'Given no open pull requests' do
+    let(:pull_requests) { [] }
+
+    it 'Returns an empty array given no pull requests' do
+      expect(results).to be_empty
+    end
+  end
+
+  context 'Given a single open pull request' do
+    let(:pull_request) do
+      Domain::PullRequest.new(
+        application_name: 'frontend',
+        title: 'Bump gds-api-adapters from 1.2.3 to 4.5.6',
+        url: 'https://www.github.com/alphagov/frontend/pull/123',
+        opened_at: Date.parse('2018-01-01 08:00:00')
+      )
+    end
+    let(:pull_requests) { [pull_request] }
+
+    it 'Returns a single pull request' do
+      expect(results.count).to eq(1)
+      expect(results).to include(pull_request)
+    end
   end
 end
-


### PR DESCRIPTION
https://trello.com/c/HtR7PDed/58-get-prs-by-dependabot

### Depends on #4 

Creates a use case for fetching pull requests. This will call a gateway which returns the PullRequest domain objects for every PR that is open for Dependabot, which will be written in a subsequent PR. 

Additionally this adds a failing feature spec for displaying a list of applications and their count of Dependabot PRs