### PR TITLE
Add usecase for sending slack messages

### DIFF
--- a/lib/loader.rb
+++ b/lib/loader.rb
@@ -3,6 +3,7 @@ require_relative './domain/team'
 
 require_relative './use_cases/fetch_pull_requests'
 require_relative './use_cases/fetch_teams'
+require_relative './use_cases/send_slack_messages'
 require_relative './gateways/pull_request'
 require_relative './gateways/slack_message'
 require_relative './gateways/team'

--- a/lib/use_cases/send_slack_messages.rb
+++ b/lib/use_cases/send_slack_messages.rb
@@ -1,0 +1,33 @@
+module UseCases
+  class SendSlackMessages
+    def initialize(slack_gateway:, team_gateway:, pull_request_gateway:)
+      @slack_gateway = slack_gateway
+      @team_gateway = team_gateway
+      @pull_request_gateway = pull_request_gateway
+    end
+
+    def execute
+      open_pull_requests = pull_request_gateway.execute
+      teams = team_gateway.execute
+
+      pull_requests_by_team = open_pull_requests.group_by do |pr|
+        team_for_application(teams, pr.application_name)
+      end
+
+      pull_requests_by_team.each do |team, pull_requests|
+        slack_gateway.execute(
+          team: team.team_name.tr('#', ''),
+          message: "You have #{pull_requests.count} open Dependabot PR(s)"
+        )
+      end
+    end
+
+  private
+
+    attr_reader :slack_gateway, :team_gateway, :pull_request_gateway
+
+    def team_for_application(teams, application_name)
+      teams.find { |team| team.applications.include?(application_name) }
+    end
+  end
+end

--- a/spec/use_cases/send_slack_messages_spec.rb
+++ b/spec/use_cases/send_slack_messages_spec.rb
@@ -1,0 +1,137 @@
+describe UseCases::SendSlackMessages do
+  context 'given no teams or pull requests' do
+    it 'does not call the slack gateway' do
+      team_gateway = double(execute: [])
+      pull_request_gateway = double(execute: [])
+      slack_gateway = double
+      expect(slack_gateway).not_to receive(:execute)
+      described_class.new(
+        slack_gateway: slack_gateway,
+        team_gateway: team_gateway,
+        pull_request_gateway: pull_request_gateway
+      ).execute
+    end
+  end
+
+  context 'given one team' do
+    context 'and no pull requests' do
+      it 'does not call the slack gateway' do
+        team_gateway = double(execute: [
+          Domain::Team.new(team_name: '#email', applications: ['whitehall'])
+        ])
+        pull_request_gateway = double(execute: [])
+        slack_gateway = double
+        expect(slack_gateway).not_to receive(:execute)
+        described_class.new(
+          slack_gateway: slack_gateway,
+          team_gateway: team_gateway,
+          pull_request_gateway: pull_request_gateway
+        ).execute
+      end
+    end
+
+    context 'and one pull request' do
+      it 'sends a single message with one pull request open' do
+        team_gateway = double(execute: [
+          Domain::Team.new(team_name: '#email', applications: ['whitehall'])
+        ])
+        pull_request_gateway = double(execute: [
+          Domain::PullRequest.new(
+            application_name: 'whitehall',
+            title: 'Bump foo 1.2.3 to 4.5.6',
+            opened_at: Date.parse('2018-01-25'),
+            url: 'https://github.com/alphagov/whitehall/123'
+          )
+        ])
+        slack_gateway = double
+        expect(slack_gateway).to receive(:execute).with(
+          team: 'email',
+          message: 'You have 1 open Dependabot PR(s)'
+        )
+        described_class.new(
+          slack_gateway: slack_gateway,
+          team_gateway: team_gateway,
+          pull_request_gateway: pull_request_gateway
+        ).execute
+      end
+    end
+
+    context 'multiple pull requests for one team' do
+      it 'sends a single message' do
+        team_gateway = double(execute: [
+          Domain::Team.new(team_name: '#email', applications: ['whitehall'])
+        ])
+        pull_request_gateway = double(execute: [
+          Domain::PullRequest.new(
+            application_name: 'whitehall',
+            title: 'Bump foo 1.2.3 to 4.5.6',
+            opened_at: Date.parse('2018-01-25'),
+            url: 'https://github.com/alphagov/whitehall/123'
+          ),
+
+          Domain::PullRequest.new(
+            application_name: 'whitehall',
+            title: 'Bump Rails from 4.2.1 to 5.1.0',
+            opened_at: Date.parse('2018-01-25'),
+            url: 'https://github.com/alphagov/whitehall/123'
+          )
+        ])
+        slack_gateway = double
+        expect(slack_gateway).to receive(:execute).with(
+          team: 'email',
+          message: 'You have 2 open Dependabot PR(s)'
+        )
+        described_class.new(
+          slack_gateway: slack_gateway,
+          team_gateway: team_gateway,
+          pull_request_gateway: pull_request_gateway
+        ).execute
+      end
+    end
+  end
+
+  context 'multiple pull requests for multiple teams' do
+    it 'sends one message to each team' do
+      team_gateway = double(execute: [
+        Domain::Team.new(team_name: '#email', applications: ['whitehall']),
+        Domain::Team.new(team_name: '#platform_support', applications: ['travel-advice-publisher'])
+      ])
+      pull_request_gateway = double(execute: [
+        Domain::PullRequest.new(
+          application_name: 'whitehall',
+          title: 'Bump foo 1.2.3 to 4.5.6',
+          opened_at: Date.parse('2018-01-25'),
+          url: 'https://github.com/alphagov/whitehall/123'
+        ),
+        Domain::PullRequest.new(
+          application_name: 'whitehall',
+          title: 'Bump Rails from 4.2.1 to 5.1.0',
+          opened_at: Date.parse('2018-01-25'),
+          url: 'https://github.com/alphagov/whitehall/457'
+        ),
+
+        Domain::PullRequest.new(
+          application_name: 'travel-advice-publisher',
+          title: 'Bump Rails from 1.3.4 to 2.0.0',
+          opened_at: Date.parse('2018-01-25'),
+          url: 'https://github.com/alphagov/travel-advice-publisher/123'
+        )
+      ])
+      slack_gateway = double
+      expect(slack_gateway).to receive(:execute).with(
+        team: 'email',
+        message: 'You have 2 open Dependabot PR(s)'
+      )
+      expect(slack_gateway).to receive(:execute).with(
+        team: 'platform_support',
+        message: 'You have 1 open Dependabot PR(s)'
+      )
+
+      described_class.new(
+        slack_gateway: slack_gateway,
+        team_gateway: team_gateway,
+        pull_request_gateway: pull_request_gateway
+      ).execute
+    end
+  end
+end


### PR DESCRIPTION
https://trello.com/c/cHx23NBz/74-generate-dependaseal-messages

There is currently duplication between this use_case and the team-view presenter that we'd like to refactor out, however to keep this PR easier to review we've kept this duplication in to refactor later 