### PR TITLE
Refactor presenters to not know about domain objects

### DIFF
--- a/lib/presenters/pull_requests_by_application.rb
+++ b/lib/presenters/pull_requests_by_application.rb
@@ -1,7 +1,9 @@
 module Presenters
   class PullRequestsByApplication
     def execute(ungrouped_pull_requests)
-      grouped_pull_requests = ungrouped_pull_requests.group_by(&:application_name)
+      grouped_pull_requests = ungrouped_pull_requests.group_by do |value|
+        value.fetch(:application_name)
+      end
 
       grouped_pull_requests.map do |application_name, pull_requests|
         {

--- a/lib/presenters/pull_requests_by_gem.rb
+++ b/lib/presenters/pull_requests_by_gem.rb
@@ -1,7 +1,7 @@
 module Presenters
   class PullRequestsByGem
     def execute(ungrouped_pull_requests)
-      grouped_pull_requests = ungrouped_pull_requests.group_by { |pr| gem_name(pr.title) }
+      grouped_pull_requests = ungrouped_pull_requests.group_by { |pr| gem_name(pr.fetch(:title)) }
       grouped_pull_requests.map do |gem_name, pull_requests|
         {
           gem_name: gem_name,

--- a/lib/presenters/pull_requests_by_team.rb
+++ b/lib/presenters/pull_requests_by_team.rb
@@ -1,9 +1,9 @@
 module Presenters
   class PullRequestsByTeam
     def execute(teams:, ungrouped_pull_requests:)
-      pull_requests_by_team = ungrouped_pull_requests.group_by { |pr| team_for_application(teams, pr.application_name) }
+      pull_requests_by_team = ungrouped_pull_requests.group_by { |pr| team_for_application(teams, pr.fetch(:application_name)) }
       pull_requests_by_team.map do |team, pull_requests|
-        pull_requests_by_application = pull_requests.group_by(&:application_name)
+        pull_requests_by_application = pull_requests.group_by { |pr| pr.fetch(:application_name) }
 
         {
           team_name: team&.team_name || 'no team',

--- a/lib/use_cases/fetch_pull_requests.rb
+++ b/lib/use_cases/fetch_pull_requests.rb
@@ -5,7 +5,17 @@ module UseCases
     end
 
     def execute
-      gateway.execute
+      pull_requests = gateway.execute
+
+      pull_requests.map do |result|
+        {
+          application_name: result.application_name,
+          title: result.title,
+          url: result.url,
+          open_since: result.open_since,
+          version: result.version
+        }
+      end
     end
 
   private

--- a/spec/presenters/pull_requests_by_application_spec.rb
+++ b/spec/presenters/pull_requests_by_application_spec.rb
@@ -7,12 +7,12 @@ describe Presenters::PullRequestsByApplication do
 
   context 'Given a single pull request' do
     it 'groups the pull request by the application name' do
-      pull_request = Domain::PullRequest.new(
+      pull_request = {
         application_name: 'frontend',
         title: 'Bump gds-api-adapters from 1.2.3 to 4.5.6',
         url: 'https://www.github.com/alphagov/frontend/pull/123',
         opened_at: Date.parse('2018-01-01 08:00:00')
-      )
+      }
 
       result = described_class.new.execute([pull_request])
       expect(result).to eq([
@@ -28,18 +28,18 @@ describe Presenters::PullRequestsByApplication do
   context 'Given multiple pull requests for a single repo' do
     it 'groups the pull requests by the application name' do
       pull_requests = [
-        Domain::PullRequest.new(
+        {
           application_name: 'frontend',
           title: 'Bump gds-api-adapters from 1.2.3 to 4.5.6',
           url: 'https://www.github.com/alphagov/frontend/pull/123',
           opened_at: Date.parse('2018-01-01 08:00:00')
-        ),
-        Domain::PullRequest.new(
+        },
+        {
           application_name: 'frontend',
           title: 'Bump uglifier from 4.5.6 to 7.8.9',
           url: 'https://www.github.com/alphagov/frontend/pull/456',
           opened_at: Date.parse('2018-01-01 08:00:00')
-        )
+        }
       ]
       result = described_class.new.execute(pull_requests)
       expect(result).to eq(
@@ -56,26 +56,26 @@ describe Presenters::PullRequestsByApplication do
 
   context 'Given pull requests for multiple applications' do
     it 'groups the pull requests by the application name' do
-      frontend_pull_request = Domain::PullRequest.new(
+      frontend_pull_request = {
         application_name: 'frontend',
         title: 'Bump gds-api-adapters from 1.2.3 to 4.5.6',
         url: 'https://www.github.com/alphagov/frontend/pull/123',
         opened_at: Date.parse('2018-01-01 08:00:00')
-      )
+      }
 
-      publisher_pull_request = Domain::PullRequest.new(
+      publisher_pull_request = {
         application_name: 'publisher',
         title: 'Bump uglifier from 4.5.6 to 7.8.9',
         url: 'https://www.github.com/alphagov/frontend/pull/456',
         opened_at: Date.parse('2018-01-01 08:00:00')
-      )
+      }
 
-      publisher_pull_request2 = Domain::PullRequest.new(
+      publisher_pull_request2 = {
         application_name: 'publisher',
         title: 'Bump uglifier from 4.5.6 to 7.8.9',
         url: 'https://www.github.com/alphagov/frontend/pull/456',
         opened_at: Date.parse('2018-01-01 08:00:00')
-      )
+      }
 
       result = described_class.new.execute(
         [

--- a/spec/presenters/pull_requests_by_gem_spec.rb
+++ b/spec/presenters/pull_requests_by_gem_spec.rb
@@ -7,12 +7,12 @@ describe Presenters::PullRequestsByGem do
 
   context 'Given a single pull request' do
     it 'groups the pull request by the gem name' do
-      pull_request = Domain::PullRequest.new(
+      pull_request = {
         application_name: 'frontend',
         title: 'Bump gds-api-adapters from 1.2.3 to 4.5.6',
         url: 'https://www.github.com/alphagov/frontend/pull/123',
         opened_at: Date.parse('2018-01-01 08:00:00')
-      )
+      }
 
       result = described_class.new.execute([pull_request])
       expect(result).to eq([
@@ -27,18 +27,18 @@ describe Presenters::PullRequestsByGem do
   context 'Given multiple pull requests for a single gem' do
     it 'groups the pull requests by the gem name' do
       pull_requests = [
-        Domain::PullRequest.new(
+        {
           application_name: 'frontend',
           title: 'Bump gds-api-adapters from 1.2.3 to 4.5.6',
           url: 'https://www.github.com/alphagov/frontend/pull/123',
           opened_at: Date.parse('2018-01-01 08:00:00')
-        ),
-        Domain::PullRequest.new(
+        },
+        {
           application_name: 'signon',
           title: 'Bump gds-api-adapters from 1.2.3 to 4.5.6',
           url: 'https://www.github.com/alphagov/frontend/pull/456',
           opened_at: Date.parse('2018-01-01 08:00:00')
-        )
+        }
       ]
       result = described_class.new.execute(pull_requests)
       expect(result).to eq([
@@ -52,26 +52,26 @@ describe Presenters::PullRequestsByGem do
 
   context 'Given pull requests for multiple gems' do
     it 'groups the pull requests by the gem' do
-      gds_api_adapters_pull_request = Domain::PullRequest.new(
+      gds_api_adapters_pull_request = {
         application_name: 'frontend',
         title: 'Bump gds-api-adapters from 1.2.3 to 4.5.6',
         url: 'https://www.github.com/alphagov/frontend/pull/123',
         opened_at: Date.parse('2018-01-01 08:00:00')
-      )
+      }
 
-      gds_api_adapters_pull_request2 = Domain::PullRequest.new(
+      gds_api_adapters_pull_request2 = {
         application_name: 'publisher',
         title: 'Bump gds-api-adapters from 4.5.6 to 7.8.9',
         url: 'https://www.github.com/alphagov/frontend/pull/456',
         opened_at: Date.parse('2018-01-01 08:00:00')
-      )
+      }
 
-      uglifier_pull_request = Domain::PullRequest.new(
+      uglifier_pull_request = {
         application_name: 'publisher',
         title: 'Bump uglifier from 4.5.6 to 7.8.9',
         url: 'https://www.github.com/alphagov/publisher/pull/456',
         opened_at: Date.parse('2018-01-01 08:00:00')
-      )
+      }
 
       result = described_class.new.execute(
         [

--- a/spec/presenters/pull_requests_by_team_spec.rb
+++ b/spec/presenters/pull_requests_by_team_spec.rb
@@ -21,12 +21,13 @@ describe Presenters::PullRequestsByTeam do
     context 'and one team that the pull request belongs to' do
       it 'returns an array of applications grouped by team' do
         team = Domain::Team.new(team_name: '#email', applications: ['signon'])
-        pull_request = Domain::PullRequest.new(
+        pull_request = {
           application_name: 'signon',
           title: 'Bump gds-api-adapters from 1.2.3 to 4.5.6',
           url: 'https://www.github.com/alphagov/signon/pull/456',
           opened_at: Date.parse('2018-01-01 08:00:00')
-        )
+        }
+
         expect(described_class.new.execute(
                  teams: [team],
                  ungrouped_pull_requests: [pull_request]
@@ -47,12 +48,12 @@ describe Presenters::PullRequestsByTeam do
 
     context 'and no teams that the pull request belongs to' do
       it 'group the pull request with the "no team" team name' do
-        pull_request = Domain::PullRequest.new(
+        pull_request = {
           application_name: 'signon',
           title: 'Bump gds-api-adapters from 1.2.3 to 4.5.6',
           url: 'https://www.github.com/alphagov/signon/pull/456',
           opened_at: Date.parse('2018-01-01 08:00:00')
-        )
+        }
 
         expect(described_class.new.execute(teams: [], ungrouped_pull_requests: [pull_request])).to eq([
           {
@@ -75,19 +76,19 @@ describe Presenters::PullRequestsByTeam do
       it 'returns an array of applications grouped by team' do
         team = Domain::Team.new(team_name: '#email', applications: ['signon', 'email-alert-api'])
         pull_requests = [
-          Domain::PullRequest.new(
+          {
             application_name: 'signon',
             title: 'Bump gds-api-adapters from 1.2.3 to 4.5.6',
             url: 'https://www.github.com/alphagov/signon/pull/456',
             opened_at: Date.parse('2018-01-01 08:00:00')
-          ),
-          Domain::PullRequest.new(
+          }, {
             application_name: 'email-alert-api',
             title: 'Bump gds-api-adapters from 1.2.3 to 4.5.6',
             url: 'https://www.github.com/alphagov/email-alert-api/pull/456',
             opened_at: Date.parse('2018-01-01 08:00:00')
-        )
-]
+          }
+        ]
+
         expect(described_class.new.execute(
                  teams: [team],
                  ungrouped_pull_requests: pull_requests
@@ -111,18 +112,19 @@ describe Presenters::PullRequestsByTeam do
 
       it 'counts the number of pull requests' do
         team = Domain::Team.new(team_name: '#email', applications: ['signon', 'email-alert-api'])
-        pull_request = Domain::PullRequest.new(
+        pull_request = {
           application_name: 'signon',
           title: 'Bump gds-api-adapters from 1.2.3 to 4.5.6',
           url: 'https://www.github.com/alphagov/signon/pull/456',
           opened_at: Date.parse('2018-01-01 08:00:00')
-        )
-        pull_request2 = Domain::PullRequest.new(
+        }
+
+        pull_request2 = {
           application_name: 'signon',
           title: 'Bump Rails from 4.2.1 to 5.1.2',
           url: 'https://www.github.com/alphagov/signon/pull/457',
           opened_at: Date.parse('2018-01-01 08:00:00')
-        )
+        }
         expect(described_class.new.execute(
                  teams: [team],
                  ungrouped_pull_requests: [pull_request, pull_request2]
@@ -147,25 +149,23 @@ describe Presenters::PullRequestsByTeam do
                  Domain::Team.new(team_name: '#asset-management', applications: ['asset-manager'])]
 
         pull_requests = [
-          Domain::PullRequest.new(
+          {
             application_name: 'signon',
             title: 'Bump gds-api-adapters from 1.2.3 to 4.5.6',
             url: 'https://www.github.com/alphagov/signon/pull/456',
             opened_at: Date.parse('2018-01-01 08:00:00')
-          ),
-          Domain::PullRequest.new(
+          }, {
             application_name: 'email-alert-api',
             title: 'Bump gds-api-adapters from 1.2.3 to 4.5.6',
             url: 'https://www.github.com/alphagov/email-alert-api/pull/456',
             opened_at: Date.parse('2018-01-01 08:00:00')
-          ),
-          Domain::PullRequest.new(
+          }, {
             application_name: 'asset-manager',
             title: 'Bump gds-api-adapters from 1.2.3 to 4.5.6',
             url: 'https://www.github.com/alphagov/email-alert-api/pull/456',
             opened_at: Date.parse('2018-01-01 08:00:00')
-        )
-]
+          }
+        ]
 
         expect(described_class.new.execute(
                  teams: teams,

--- a/spec/use_cases/fetch_pull_requests_spec.rb
+++ b/spec/use_cases/fetch_pull_requests_spec.rb
@@ -1,8 +1,67 @@
 describe UseCases::FetchPullRequests do
   it 'Calls execute on the gateway' do
-    pull_request_gateway = double
-    expect(pull_request_gateway).to receive(:execute).once
+    pull_request_gateway = double(execute: [])
+    result = described_class.new(gateway: pull_request_gateway).execute
+    expect(result).to eq([])
+  end
 
-    described_class.new(gateway: pull_request_gateway).execute
+  context 'Given one pull request' do
+    it 'returns a single formtted result' do
+      pull_request_gateway = double(execute: [
+        Domain::PullRequest.new(
+          application_name: 'frontend',
+          title: 'Bump Rails from 4.2 to 5.0',
+          opened_at: Date.today,
+          url: 'https://github.com/alphagov/frontend/pulls/123'
+        )
+      ])
+
+      result = described_class.new(gateway: pull_request_gateway).execute
+
+      expect(result).to eq([{
+        application_name: 'frontend',
+        title: 'Bump Rails from 4.2 to 5.0',
+        url: 'https://github.com/alphagov/frontend/pulls/123',
+        open_since: 'today',
+        version: '5.0'
+      }])
+    end
+  end
+
+  context 'Given multiple pull requests' do
+    it 'returns a list of formatted results' do
+      pull_request_gateway = double(execute: [
+        Domain::PullRequest.new(
+          application_name: 'frontend',
+          title: 'Bump Rails from 4.2 to 5.0',
+          opened_at: Date.today,
+          url: 'https://github.com/alphagov/frontend/pulls/123'
+        ),
+        Domain::PullRequest.new(
+          application_name: 'publisher',
+          title: 'Bump Rails from 3.2 to 4.0',
+          opened_at: Date.today,
+          url: 'https://github.com/alphagov/publisher/pulls/123'
+        )
+      ])
+
+      result = described_class.new(gateway: pull_request_gateway).execute
+
+      expect(result).to eq([
+        {
+          application_name: 'frontend',
+          title: 'Bump Rails from 4.2 to 5.0',
+          url: 'https://github.com/alphagov/frontend/pulls/123',
+          open_since: 'today',
+          version: '5.0'
+        }, {
+          application_name: 'publisher',
+          title: 'Bump Rails from 3.2 to 4.0',
+          url: 'https://github.com/alphagov/publisher/pulls/123',
+          open_since: 'today',
+          version: '4.0'
+        },
+      ])
+    end
   end
 end

--- a/views/gem.erb
+++ b/views/gem.erb
@@ -10,10 +10,10 @@
         <ul class="pulls">
           <% gem.fetch(:pull_requests).each do |pull_request| %>
             <li class="pull">
-              <a href="<%= pull_request.url %>">
-                <%= pull_request.application_name %> (<%= pull_request.version %>)
+              <a href="<%= pull_request.fetch(:url) %>">
+                <%= pull_request.fetch(:application_name) %>
               </a>
-              <span class="time-elapsed">Opened <%= pull_request.open_since %></span>
+              <span class="time-elapsed">Opened <%= pull_request.fetch(:open_since) %></span>
             </li>
           <% end %>
         </ul>

--- a/views/index.erb
+++ b/views/index.erb
@@ -12,10 +12,10 @@
         <ul class="pulls">
           <% application.fetch(:pull_requests).each do |pull_request| %>
             <li class="pull">
-              <a href="<%= pull_request.url %>">
-                <%= pull_request.title %>
+              <a href="<%= pull_request.fetch(:url) %>">
+                <%= pull_request.fetch(:title) %>
               </a>
-              <span class="time-elapsed">Opened <%= pull_request.open_since %></span>
+              <span class="time-elapsed">Opened <%= pull_request.fetch(:open_since) %></span>
             </li>
           <% end %>
         </ul>


### PR DESCRIPTION
Dependabot sometimes bumps two gems at the same time and summarises the message that we depend on for generating results.

"Bump Rails from x to y"
"Bump Rspec from x to y"

becomes:
"Bump Rails and Rspec"

This is a refactoring to make it easier to address this bug in a usecase by decoupling the domain objects from the presenters.

https://trello.com/c/A43JQFQy/88-gem-view-bug-when-dependabot-bumps-2-gems-at-once-and-summarises-the-message