### PR TITLE
Gem view grouped pull requests bug

### DIFF
--- a/lib/domain/pull_request.rb
+++ b/lib/domain/pull_request.rb
@@ -1,13 +1,12 @@
 module Domain
   class PullRequest
-    attr_reader :application_name, :title, :open_since, :url, :version
+    attr_reader :application_name, :title, :open_since, :url
 
     def initialize(application_name:, title:, opened_at:, url:)
       @application_name = application_name
       @title = title
       @open_since = days_open(opened_at)
       @url = url
-      @version = version_from_title(title)
     end
 
   private
@@ -22,10 +21,6 @@ module Domain
       else
         "#{days} days ago"
       end
-    end
-
-    def version_from_title(title)
-      title.split(' ').last
     end
   end
 end

--- a/lib/presenters/pull_requests_by_gem.rb
+++ b/lib/presenters/pull_requests_by_gem.rb
@@ -13,7 +13,7 @@ module Presenters
   private
 
     def gem_name(pull_request_title)
-      pull_request_title.match('Bump (\S+) from')[1]
+      pull_request_title.match('Bump (\S+)')[1]
     end
   end
 end

--- a/lib/use_cases/fetch_pull_requests.rb
+++ b/lib/use_cases/fetch_pull_requests.rb
@@ -5,20 +5,40 @@ module UseCases
     end
 
     def execute
-      pull_requests = gateway.execute
-
-      pull_requests.map do |result|
+      pull_request_hash = gateway.execute.map do |result|
         {
           application_name: result.application_name,
           title: result.title,
           url: result.url,
-          open_since: result.open_since,
-          version: result.version
+          open_since: result.open_since
         }
       end
+
+      split_summarised_pull_requests(pull_request_hash)
     end
 
   private
+
+    SUMMARISED_PR_TITLE_MATCH = 'Bump (\S+) and (\S+)'.freeze
+
+    def split_summarised_pull_requests(pull_requests)
+      pull_requests.map { |pr| split_pull_request(pr) }.flatten
+    end
+
+    def split_pull_request(pr)
+      return pr unless two_gems_bumped?(pr)
+
+      gems = pr[:title].match(SUMMARISED_PR_TITLE_MATCH)
+
+      [
+        pr.merge(title: "Bump #{gems[1]}"),
+        pr.merge(title: "Bump #{gems[2]}")
+      ]
+    end
+
+    def two_gems_bumped?(pr)
+      pr[:title].match?(SUMMARISED_PR_TITLE_MATCH)
+    end
 
     attr_reader :gateway
   end

--- a/lib/use_cases/fetch_pull_requests.rb
+++ b/lib/use_cases/fetch_pull_requests.rb
@@ -19,25 +19,24 @@ module UseCases
 
   private
 
-    SUMMARISED_PR_TITLE_MATCH = 'Bump (\S+) and (\S+)'.freeze
+    SINGLE_GEM_TITLE_MATCH = 'Bump \S+ from \S+ to \S+'.freeze
 
     def split_summarised_pull_requests(pull_requests)
       pull_requests.map { |pr| split_pull_request(pr) }.flatten
     end
 
     def split_pull_request(pr)
-      return pr unless two_gems_bumped?(pr)
+      return pr if one_gem_bumped?(pr)
 
-      gems = pr[:title].match(SUMMARISED_PR_TITLE_MATCH)
-
-      [
-        pr.merge(title: "Bump #{gems[1]}"),
-        pr.merge(title: "Bump #{gems[2]}")
-      ]
+      gems_from_title(pr[:title]).map { |gem| pr.merge(title: "Bump #{gem.strip}") }
     end
 
-    def two_gems_bumped?(pr)
-      pr[:title].match?(SUMMARISED_PR_TITLE_MATCH)
+    def one_gem_bumped?(pr)
+      pr[:title].match?(SINGLE_GEM_TITLE_MATCH)
+    end
+
+    def gems_from_title(title)
+      title.sub('Bump ', '').sub('and', ',').split(',')
     end
 
     attr_reader :gateway

--- a/spec/presenters/pull_requests_by_gem_spec.rb
+++ b/spec/presenters/pull_requests_by_gem_spec.rb
@@ -24,6 +24,34 @@ describe Presenters::PullRequestsByGem do
     end
   end
 
+  context 'Given a split commit' do
+    it 'Groups them correctly' do
+      gds_api_adapter_pull_request = {
+        application_name: 'frontend',
+        title: 'Bump gds-api-adapters',
+        url: 'https://www.github.com/alphagov/frontend/pull/123',
+        opened_at: Date.parse('2018-01-01 08:00:00')
+      }
+      rspec_pull_request = {
+        application_name: 'frontend',
+        title: 'Bump Rspec',
+        url: 'https://www.github.com/alphagov/frontend/pull/123',
+        opened_at: Date.parse('2018-01-01 08:00:00')
+      }
+
+      result = described_class.new.execute([gds_api_adapter_pull_request, rspec_pull_request])
+      expect(result).to eq([
+        {
+          gem_name: 'gds-api-adapters',
+          pull_requests: [gds_api_adapter_pull_request]
+        }, {
+          gem_name: 'Rspec',
+          pull_requests: [rspec_pull_request]
+        }
+      ])
+    end
+  end
+
   context 'Given multiple pull requests for a single gem' do
     it 'groups the pull requests by the gem name' do
       pull_requests = [

--- a/spec/use_cases/fetch_pull_requests_spec.rb
+++ b/spec/use_cases/fetch_pull_requests_spec.rb
@@ -22,9 +22,35 @@ describe UseCases::FetchPullRequests do
         application_name: 'frontend',
         title: 'Bump Rails from 4.2 to 5.0',
         url: 'https://github.com/alphagov/frontend/pulls/123',
-        open_since: 'today',
-        version: '5.0'
+        open_since: 'today'
       }])
+    end
+
+    context 'with a pull request which bumps two gems' do
+      it 'returns two pull request hashes' do
+        pull_request_gateway = double(execute: [
+          Domain::PullRequest.new(
+            application_name: 'frontend',
+            title: 'Bump Rails and gds-api-adapters',
+            opened_at: Date.today,
+            url: 'https://github.com/alphagov/frontend/pulls/123'
+          )
+        ])
+
+        result = described_class.new(gateway: pull_request_gateway).execute
+
+        expect(result).to eq([{
+          application_name: 'frontend',
+          title: 'Bump Rails',
+          url: 'https://github.com/alphagov/frontend/pulls/123',
+          open_since: 'today'
+        }, {
+          application_name: 'frontend',
+          title: 'Bump gds-api-adapters',
+          url: 'https://github.com/alphagov/frontend/pulls/123',
+          open_since: 'today'
+        }])
+      end
     end
   end
 
@@ -52,14 +78,12 @@ describe UseCases::FetchPullRequests do
           application_name: 'frontend',
           title: 'Bump Rails from 4.2 to 5.0',
           url: 'https://github.com/alphagov/frontend/pulls/123',
-          open_since: 'today',
-          version: '5.0'
+          open_since: 'today'
         }, {
           application_name: 'publisher',
           title: 'Bump Rails from 3.2 to 4.0',
           url: 'https://github.com/alphagov/publisher/pulls/123',
-          open_since: 'today',
-          version: '4.0'
+          open_since: 'today'
         },
       ])
     end

--- a/spec/use_cases/fetch_pull_requests_spec.rb
+++ b/spec/use_cases/fetch_pull_requests_spec.rb
@@ -52,6 +52,38 @@ describe UseCases::FetchPullRequests do
         }])
       end
     end
+
+    context 'with a pull request which bumps three gems' do
+      it 'returns three pull request hashes' do
+        pull_request_gateway = double(execute: [
+          Domain::PullRequest.new(
+            application_name: 'frontend',
+            title: 'Bump Rails, Rspec and gds-api-adapters',
+            opened_at: Date.today,
+            url: 'https://github.com/alphagov/frontend/pulls/123'
+          )
+        ])
+
+        result = described_class.new(gateway: pull_request_gateway).execute
+
+        expect(result).to eq([{
+          application_name: 'frontend',
+          title: 'Bump Rails',
+          url: 'https://github.com/alphagov/frontend/pulls/123',
+          open_since: 'today'
+        }, {
+          application_name: 'frontend',
+          title: 'Bump Rspec',
+          url: 'https://github.com/alphagov/frontend/pulls/123',
+          open_since: 'today'
+        }, {
+          application_name: 'frontend',
+          title: 'Bump gds-api-adapters',
+          url: 'https://github.com/alphagov/frontend/pulls/123',
+          open_since: 'today'
+        }])
+      end
+    end
   end
 
   context 'Given multiple pull requests' do


### PR DESCRIPTION
This caters for a summarised pull request title by Dependabot.

It splits a summarised pull request message into 2 separate pull requests to be displayed on the Gem view page.

https://trello.com/c/A43JQFQy/88-gem-view-bug-when-dependabot-bumps-2-gems-at-once-and-summarises-the-message