### PR TITLE
Add rake for heroku scheduler

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,6 +3,7 @@ source 'https://rubygems.org'
 ruby File.read('.ruby-version').chomp
 
 gem 'octokit', '~> 4.3'
+gem 'rake', '~> 12.3.0'
 gem 'sinatra'
 gem 'slack-poster', '~> 2.2'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -97,6 +97,7 @@ DEPENDENCIES
   govuk-lint
   octokit (~> 4.3)
   rack-test (~> 0.8.0)
+  rake (~> 12.3.0)
   rspec (~> 3.7.0)
   sinatra
   slack-poster (~> 2.2)


### PR DESCRIPTION
Heroku scheduler was failing with the following message: 

`bundler: failed to load command: rake (/app/bin/rake)` as it was not in the gemfile