### PR TITLE
Indicate older PRs on the view page

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -7,6 +7,19 @@ def cache(name)
   UseCases::Cache.new(path: "#{Dir.pwd}/public/cache/#{name}.html").execute { yield }
 end
 
+def old_pull_request?(date)
+  today = Date.today
+  actual_age = (today - date).to_i
+  if today.monday?
+    weekdays_age = actual_age - 2
+  elsif today.tuesday?
+    weekdays_age = actual_age - 1
+  else
+    weekdays_age = actual_age
+  end
+  weekdays_age > 2
+end
+
 class GovukDependencies < Sinatra::Base
   get '/' do
     cache :pull_requests_by_application do

--- a/lib/domain/pull_request.rb
+++ b/lib/domain/pull_request.rb
@@ -1,10 +1,11 @@
 module Domain
   class PullRequest
-    attr_reader :application_name, :title, :open_since, :url
+    attr_reader :application_name, :title, :opened_at, :open_since, :url
 
     def initialize(application_name:, title:, opened_at:, url:)
       @application_name = application_name
       @title = title
+      @opened_at = opened_at
       @open_since = days_open(opened_at)
       @url = url
     end

--- a/lib/use_cases/fetch_pull_requests.rb
+++ b/lib/use_cases/fetch_pull_requests.rb
@@ -10,6 +10,7 @@ module UseCases
           application_name: result.application_name,
           title: result.title,
           url: result.url,
+          opened_at: result.opened_at,
           open_since: result.open_since
         }
       end

--- a/public/assets/application.css
+++ b/public/assets/application.css
@@ -58,7 +58,7 @@ nav a, nav a:visited {
   margin: 0;
 }
 
-.app a {
+a {
   color: white;
   text-decoration: none;
 }
@@ -78,6 +78,12 @@ nav a, nav a:visited {
 
 .pull {
   margin: 10px 0;
+  line-height: 1.25em;
+}
+
+.warning {
+  color: red;
+  font-weight: 800;
 }
 
 h2 {

--- a/spec/gateways/pull_request_spec.rb
+++ b/spec/gateways/pull_request_spec.rb
@@ -34,11 +34,13 @@ describe Gateways::PullRequest do
         expect(result[0].title).to eq('Bump gds-sso from 13.5.0 to 13.5.1')
         expect(result[0].application_name).to eq('publisher')
         expect(result[0].url).to eq('https://github.com/alphagov/publisher/pull/761')
+        expect(result[0].opened_at).to eq(Date.parse('2018-01-24'))
         expect(result[0].open_since).to eq('yesterday')
 
         expect(result[1].title).to eq('Bump gds-sso from 13.5.0 to 13.5.1')
         expect(result[1].application_name).to eq('frontend')
         expect(result[1].url).to eq('https://github.com/alphagov/frontend/pull/1146')
+        expect(result[1].opened_at).to eq(Date.parse('2018-01-24'))
         expect(result[1].open_since).to eq('yesterday')
       end
     end

--- a/spec/use_cases/fetch_pull_requests_spec.rb
+++ b/spec/use_cases/fetch_pull_requests_spec.rb
@@ -22,6 +22,7 @@ describe UseCases::FetchPullRequests do
         application_name: 'frontend',
         title: 'Bump Rails from 4.2 to 5.0',
         url: 'https://github.com/alphagov/frontend/pulls/123',
+        opened_at: Date.today,
         open_since: 'today'
       }])
     end
@@ -43,11 +44,13 @@ describe UseCases::FetchPullRequests do
           application_name: 'frontend',
           title: 'Bump Rails',
           url: 'https://github.com/alphagov/frontend/pulls/123',
+          opened_at: Date.today,
           open_since: 'today'
         }, {
           application_name: 'frontend',
           title: 'Bump gds-api-adapters',
           url: 'https://github.com/alphagov/frontend/pulls/123',
+          opened_at: Date.today,
           open_since: 'today'
         }])
       end
@@ -70,16 +73,19 @@ describe UseCases::FetchPullRequests do
           application_name: 'frontend',
           title: 'Bump Rails',
           url: 'https://github.com/alphagov/frontend/pulls/123',
+          opened_at: Date.today,
           open_since: 'today'
         }, {
           application_name: 'frontend',
           title: 'Bump Rspec',
           url: 'https://github.com/alphagov/frontend/pulls/123',
+          opened_at: Date.today,
           open_since: 'today'
         }, {
           application_name: 'frontend',
           title: 'Bump gds-api-adapters',
           url: 'https://github.com/alphagov/frontend/pulls/123',
+          opened_at: Date.today,
           open_since: 'today'
         }])
       end
@@ -110,11 +116,13 @@ describe UseCases::FetchPullRequests do
           application_name: 'frontend',
           title: 'Bump Rails from 4.2 to 5.0',
           url: 'https://github.com/alphagov/frontend/pulls/123',
+          opened_at: Date.today,
           open_since: 'today'
         }, {
           application_name: 'publisher',
           title: 'Bump Rails from 3.2 to 4.0',
           url: 'https://github.com/alphagov/publisher/pulls/123',
+          opened_at: Date.today,
           open_since: 'today'
         },
       ])

--- a/views/gem.erb
+++ b/views/gem.erb
@@ -9,8 +9,8 @@
         </h2>
         <ul class="pulls">
           <% gem.fetch(:pull_requests).each do |pull_request| %>
-            <li class="pull">
-              <a href="<%= pull_request.fetch(:url) %>">
+            <li class="pull <%= old_pull_request?(pull_request.fetch(:opened_at))? 'warning' : '' %>">
+              <a class="<%= old_pull_request?(pull_request.fetch(:opened_at))? 'warning' : '' %>" href="<%= pull_request.fetch(:url) %>">
                 <%= pull_request.fetch(:application_name) %>
               </a>
               <span class="time-elapsed">Opened <%= pull_request.fetch(:open_since) %></span>

--- a/views/index.erb
+++ b/views/index.erb
@@ -11,10 +11,10 @@
         </h2>
         <ul class="pulls">
           <% application.fetch(:pull_requests).each do |pull_request| %>
-            <li class="pull">
-              <a href="<%= pull_request.fetch(:url) %>">
+            <li class="pull <%= old_pull_request?(pull_request.fetch(:opened_at))? 'warning' : '' %>">
+              <a class="<%= old_pull_request?(pull_request.fetch(:opened_at))? 'warning' : '' %>" href="<%= pull_request.fetch(:url) %>">
                 <%= pull_request.fetch(:title) %>
-              </a>
+             </a>
               <span class="time-elapsed">Opened <%= pull_request.fetch(:open_since) %></span>
             </li>
           <% end %>


### PR DESCRIPTION
The code to determine whether or not a PR is considered old is taken from the seal here: https://github.com/alphagov/seal/blob/master/lib/message_builder.rb

![screenshot from 2018-02-06 16-43-41](https://user-images.githubusercontent.com/976254/35872040-b3afda2e-0b5d-11e8-9a8c-1665351eb999.png)

https://trello.com/c/R4VlA24a/97-indicate-old-prs-in-some-way