### PR TITLE
Update advisory DB on requests to the security alerts page

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -84,6 +84,8 @@ class GovukDependencies < Sinatra::Base
 
   get '/security-alerts' do
     cache :security_alerts, 43200 do
+      Bundler::Audit::Database.update!
+
       UseCases::Gemfiles::Save.new(
         fetch_gemfiles: UseCases::Gemfiles::Fetch.new(
           teams_use_case: UseCases::Teams::Fetch.new


### PR DESCRIPTION
Due to running on different Dynos - we need to update this on the dyno the webserver is running on