### PR TITLE
Make Slack messages smaller

### DIFF
--- a/lib/presenters/slack/full_message.rb
+++ b/lib/presenters/slack/full_message.rb
@@ -4,7 +4,7 @@ module Presenters
       def execute(applications_by_team:)
         "#{url_for_team(applications_by_team)} have #{pull_requests_count(applications_by_team)} Dependabot PRs open on the following apps:
 
-#{body(applications_by_team).join("\n")}
+#{body(applications_by_team).join(" ")}
 
 Feedback: https://trello.com/b/jQrIfH9A/dependabot-developer-feedback"
       end

--- a/lib/presenters/slack/full_message.rb
+++ b/lib/presenters/slack/full_message.rb
@@ -4,9 +4,7 @@ module Presenters
       def execute(applications_by_team:)
         "#{url_for_team(applications_by_team)} have #{pull_requests_count(applications_by_team)} Dependabot PRs open on the following apps:
 
-#{body(applications_by_team).join(" ")}
-
-Feedback: https://trello.com/b/jQrIfH9A/dependabot-developer-feedback"
+#{body(applications_by_team).join(" ")}"
       end
 
     private

--- a/lib/presenters/slack/full_message.rb
+++ b/lib/presenters/slack/full_message.rb
@@ -4,7 +4,7 @@ module Presenters
       def execute(applications_by_team:)
         "#{url_for_team(applications_by_team)} have #{pull_requests_count(applications_by_team)} Dependabot PRs open on the following apps:
 
-#{body(applications_by_team).join(" ")}"
+#{body(applications_by_team).join(' ')}"
       end
 
     private

--- a/lib/presenters/slack/simple_message.rb
+++ b/lib/presenters/slack/simple_message.rb
@@ -2,7 +2,7 @@ module Presenters
   module Slack
     class SimpleMessage
       def execute(applications_by_team:)
-        "You have #{pull_requests_count(applications_by_team)} open Dependabot PR(s) - #{url(applications_by_team)} - Feedback: https://trello.com/b/jQrIfH9A/dependabot-developer-feedback"
+        "You have #{pull_requests_count(applications_by_team)} open Dependabot PR(s) - #{url(applications_by_team)}"
       end
 
     private

--- a/lib/use_cases/slack/schedulers/weekday.rb
+++ b/lib/use_cases/slack/schedulers/weekday.rb
@@ -2,22 +2,15 @@ module UseCases
   module Slack
     module Schedulers
       class Weekday
-        def initialize(date_class: Date.new)
-          @date_class = date_class
-        end
-
         def should_send_message?
-          return false if weekend?
-
-          true
+          !weekend?
         end
 
       private
 
-        attr_reader :date_class
-
         def weekend?
-          date_class.saturday? || date_class.sunday?
+          date = Time.now
+          date.saturday? || date.sunday?
         end
       end
     end

--- a/spec/acceptance/dependapanda_spec.rb
+++ b/spec/acceptance/dependapanda_spec.rb
@@ -23,11 +23,11 @@ describe Dependapanda do
   context 'Simple Message' do
     it 'sends a summarised message' do
       modelling_services_payload = {
-        'payload' => '{"channel":"modelling-services","username":"Dependapanda","icon_emoji":":panda_face:","text":"You have 2 open Dependabot PR(s) - https://govuk-dependencies.herokuapp.com/team/modelling-services - Feedback: https://trello.com/b/jQrIfH9A/dependabot-developer-feedback"}'
+        'payload' => '{"channel":"modelling-services","username":"Dependapanda","icon_emoji":":panda_face:","text":"You have 2 open Dependabot PR(s) - https://govuk-dependencies.herokuapp.com/team/modelling-services"}'
       }
 
       start_pages_payload = {
-        'payload' => '{"channel":"start-pages","username":"Dependapanda","icon_emoji":":panda_face:","text":"You have 1 open Dependabot PR(s) - https://govuk-dependencies.herokuapp.com/team/start-pages - Feedback: https://trello.com/b/jQrIfH9A/dependabot-developer-feedback"}'
+        'payload' => '{"channel":"start-pages","username":"Dependapanda","icon_emoji":":panda_face:","text":"You have 1 open Dependabot PR(s) - https://govuk-dependencies.herokuapp.com/team/start-pages"}'
       }
 
       described_class.new.send_simple_message
@@ -40,11 +40,11 @@ describe Dependapanda do
   context 'Full Message' do
     it 'sends all the pull requests in the message' do
       modelling_services_payload = {
-        'payload' => '{"channel":"modelling-services","username":"Dependapanda","icon_emoji":":panda_face:","text":"<https://govuk-dependencies.herokuapp.com/team/modelling-services|modelling-services> have 2 Dependabot PRs open on the following apps:\n\n<https://github.com/alphagov/publisher/pulls/app/dependabot|publisher> (2)\n\nFeedback: https://trello.com/b/jQrIfH9A/dependabot-developer-feedback"}'
+        'payload' => '{"channel":"modelling-services","username":"Dependapanda","icon_emoji":":panda_face:","text":"<https://govuk-dependencies.herokuapp.com/team/modelling-services|modelling-services> have 2 Dependabot PRs open on the following apps:\n\n<https://github.com/alphagov/publisher/pulls/app/dependabot|publisher> (2)"}'
       }
 
       start_pages_payload = {
-        'payload' => '{"channel":"start-pages","username":"Dependapanda","icon_emoji":":panda_face:","text":"<https://govuk-dependencies.herokuapp.com/team/start-pages|start-pages> have 1 Dependabot PRs open on the following apps:\n\n<https://github.com/alphagov/frontend/pulls/app/dependabot|frontend> (1)\n\nFeedback: https://trello.com/b/jQrIfH9A/dependabot-developer-feedback"}'
+        'payload' => '{"channel":"start-pages","username":"Dependapanda","icon_emoji":":panda_face:","text":"<https://govuk-dependencies.herokuapp.com/team/start-pages|start-pages> have 1 Dependabot PRs open on the following apps:\n\n<https://github.com/alphagov/frontend/pulls/app/dependabot|frontend> (1)"}'
       }
 
       described_class.new.send_full_message

--- a/spec/presenters/slack/full_message_spec.rb
+++ b/spec/presenters/slack/full_message_spec.rb
@@ -16,9 +16,7 @@ describe Presenters::Slack::FullMessage do
 
       expect(result).to eq('<https://govuk-dependencies.herokuapp.com/team/email|email> have 1 Dependabot PRs open on the following apps:
 
-<https://github.com/alphagov/content-tagger/pulls/app/dependabot|content-tagger> (1)
-
-Feedback: https://trello.com/b/jQrIfH9A/dependabot-developer-feedback')
+<https://github.com/alphagov/content-tagger/pulls/app/dependabot|content-tagger> (1)')
     end
   end
 
@@ -43,9 +41,7 @@ Feedback: https://trello.com/b/jQrIfH9A/dependabot-developer-feedback')
 
       expect(result).to eq('<https://govuk-dependencies.herokuapp.com/team/taxonomy|taxonomy> have 2 Dependabot PRs open on the following apps:
 
-<https://github.com/alphagov/collections-publisher/pulls/app/dependabot|collections-publisher> (1) <https://github.com/alphagov/content-tagger/pulls/app/dependabot|content-tagger> (1)
-
-Feedback: https://trello.com/b/jQrIfH9A/dependabot-developer-feedback')
+<https://github.com/alphagov/collections-publisher/pulls/app/dependabot|collections-publisher> (1) <https://github.com/alphagov/content-tagger/pulls/app/dependabot|content-tagger> (1)')
     end
 
     it 'groups by application' do
@@ -68,9 +64,7 @@ Feedback: https://trello.com/b/jQrIfH9A/dependabot-developer-feedback')
 
       expect(result).to eq('<https://govuk-dependencies.herokuapp.com/team/taxonomy|taxonomy> have 3 Dependabot PRs open on the following apps:
 
-<https://github.com/alphagov/collections-publisher/pulls/app/dependabot|collections-publisher> (1) <https://github.com/alphagov/content-tagger/pulls/app/dependabot|content-tagger> (2)
-
-Feedback: https://trello.com/b/jQrIfH9A/dependabot-developer-feedback')
+<https://github.com/alphagov/collections-publisher/pulls/app/dependabot|collections-publisher> (1) <https://github.com/alphagov/content-tagger/pulls/app/dependabot|content-tagger> (2)')
     end
   end
 end

--- a/spec/presenters/slack/full_message_spec.rb
+++ b/spec/presenters/slack/full_message_spec.rb
@@ -43,8 +43,7 @@ Feedback: https://trello.com/b/jQrIfH9A/dependabot-developer-feedback')
 
       expect(result).to eq('<https://govuk-dependencies.herokuapp.com/team/taxonomy|taxonomy> have 2 Dependabot PRs open on the following apps:
 
-<https://github.com/alphagov/collections-publisher/pulls/app/dependabot|collections-publisher> (1)
-<https://github.com/alphagov/content-tagger/pulls/app/dependabot|content-tagger> (1)
+<https://github.com/alphagov/collections-publisher/pulls/app/dependabot|collections-publisher> (1) <https://github.com/alphagov/content-tagger/pulls/app/dependabot|content-tagger> (1)
 
 Feedback: https://trello.com/b/jQrIfH9A/dependabot-developer-feedback')
     end
@@ -69,8 +68,7 @@ Feedback: https://trello.com/b/jQrIfH9A/dependabot-developer-feedback')
 
       expect(result).to eq('<https://govuk-dependencies.herokuapp.com/team/taxonomy|taxonomy> have 3 Dependabot PRs open on the following apps:
 
-<https://github.com/alphagov/collections-publisher/pulls/app/dependabot|collections-publisher> (1)
-<https://github.com/alphagov/content-tagger/pulls/app/dependabot|content-tagger> (2)
+<https://github.com/alphagov/collections-publisher/pulls/app/dependabot|collections-publisher> (1) <https://github.com/alphagov/content-tagger/pulls/app/dependabot|content-tagger> (2)
 
 Feedback: https://trello.com/b/jQrIfH9A/dependabot-developer-feedback')
     end

--- a/spec/presenters/slack/simple_message_spec.rb
+++ b/spec/presenters/slack/simple_message_spec.rb
@@ -13,7 +13,7 @@ describe Presenters::Slack::SimpleMessage do
       }
       result = described_class.new.execute(applications_by_team: applications_by_team)
 
-      expect(result).to eq('You have 1 open Dependabot PR(s) - https://govuk-dependencies.herokuapp.com/team/email - Feedback: https://trello.com/b/jQrIfH9A/dependabot-developer-feedback')
+      expect(result).to eq('You have 1 open Dependabot PR(s) - https://govuk-dependencies.herokuapp.com/team/email')
     end
   end
 end

--- a/spec/use_cases/slack/schedulers/weekday_spec.rb
+++ b/spec/use_cases/slack/schedulers/weekday_spec.rb
@@ -1,39 +1,23 @@
 describe UseCases::Slack::Schedulers::Weekday do
   context 'Given it is the weekend' do
     it 'does not send messages on Saturday' do
-      date_class = double(
-        saturday?: true,
-        sunday?: false
-      )
-
-      expect(
-        described_class.new(date_class: date_class).should_send_message?
-      ).to be false
+      Timecop.freeze("2018-04-14") do
+        expect(subject.should_send_message?).to be false
+      end
     end
 
     it 'does not send messages on Sunday' do
-      date_class = double(
-        saturday?: false,
-        sunday?: true
-      )
-
-      expect(
-        described_class.new(date_class: date_class).should_send_message?
-      ).to be false
+      Timecop.freeze("2018-04-15") do
+        expect(subject.should_send_message?).to be false
+      end
     end
   end
 
   context 'Given it is a week day' do
     it 'should_send_slack_messages? is true' do
-      date_class = double(
-        saturday?: false,
-        sunday?: false,
-        monday?: true
-      )
-
-      expect(
-        described_class.new(date_class: date_class).should_send_message?
-      ).to be true
+      Timecop.freeze("2018-04-13") do
+        expect(subject.should_send_message?).to be true
+      end
     end
   end
 end


### PR DESCRIPTION
This makes the Slack messages smaller by putting all the repos on one line rather than on separate lines. I've also removed the feedback link as it doesn't seem to be used and we can take feedback in this repo.

Also fixed a bug meaning that messages were still being send on the weekend.

[Trello Card](https://trello.com/c/LpIHFgQv/34-2-stop-getting-spammed-in-slack-about-dependencies)