### PR TITLE
Update Dependabot app name

### DIFF
--- a/lib/gateways/pull_request.rb
+++ b/lib/gateways/pull_request.rb
@@ -13,17 +13,17 @@ module Gateways
   private
 
     def approved_pull_requests
-      approved_pull_requests = @octokit.search_issues('is:pr user:alphagov state:open author:app/dependabot review:approved').items
+      approved_pull_requests = @octokit.search_issues('is:pr user:alphagov state:open author:app/dependabot-preview review:approved').items
       build_pull_requests(approved_pull_requests, 'approved')
     end
 
     def review_required_pull_requests
-      review_required_pull_requests = @octokit.search_issues('is:pr user:alphagov state:open author:app/dependabot review:required').items
+      review_required_pull_requests = @octokit.search_issues('is:pr user:alphagov state:open author:app/dependabot-preview review:required').items
       build_pull_requests(review_required_pull_requests, 'review required')
     end
 
     def changes_requested_pull_requests
-      changes_requested_pull_requests = @octokit.search_issues('is:pr user:alphagov state:open author:app/dependabot review:changes_requested').items
+      changes_requested_pull_requests = @octokit.search_issues('is:pr user:alphagov state:open author:app/dependabot-preview review:changes_requested').items
       build_pull_requests(changes_requested_pull_requests, 'changes requested')
     end
 

--- a/lib/gateways/pull_request_count.rb
+++ b/lib/gateways/pull_request_count.rb
@@ -5,7 +5,7 @@ module Gateways
     end
 
     def execute
-      @octokit.search_issues('is:pr user:alphagov author:app/dependabot').total_count
+      @octokit.search_issues('is:pr user:alphagov author:app/dependabot-preview').total_count
     end
   end
 end

--- a/lib/presenters/slack/full_message.rb
+++ b/lib/presenters/slack/full_message.rb
@@ -17,7 +17,7 @@ module Presenters
       end
 
       def url(application_name)
-        "https://github.com/alphagov/#{application_name}/pulls/app/dependabot"
+        "https://github.com/alphagov/#{application_name}/pulls/app/dependabot-preview"
       end
 
       def url_for_team(applications_by_team)

--- a/lib/use_cases/group/applications_by_team.rb
+++ b/lib/use_cases/group/applications_by_team.rb
@@ -36,7 +36,7 @@ module UseCases
         pull_requests_by_application.map do |application_name, pull_request_for_app|
           {
             application_name: application_name,
-            application_url: "https://github.com/alphagov/#{application_name}/pulls/app/dependabot",
+            application_url: "https://github.com/alphagov/#{application_name}/pulls/app/dependabot-preview",
             pull_request_count: pull_request_for_app.count
           }
         end

--- a/spec/acceptance/app_spec.rb
+++ b/spec/acceptance/app_spec.rb
@@ -19,11 +19,11 @@ describe GovukDependencies do
   context 'Dashboard' do
     context 'given open pull requests' do
       before do
-        stub_request(:get, 'https://api.github.com/search/issues?per_page=100&q=is:pr+user:alphagov+state:open+author:app/dependabot+review:approved')
+        stub_request(:get, 'https://api.github.com/search/issues?per_page=100&q=is:pr+user:alphagov+state:open+author:app/dependabot-preview+review:approved')
           .to_return(body: '{ "total_count": 0, "incomplete_results": false, "items": [] }', headers: { 'Content-Type' => 'application/json' })
-        stub_request(:get, 'https://api.github.com/search/issues?per_page=100&q=is:pr+user:alphagov+state:open+author:app/dependabot+review:required')
+        stub_request(:get, 'https://api.github.com/search/issues?per_page=100&q=is:pr+user:alphagov+state:open+author:app/dependabot-preview+review:required')
           .to_return(body: File.read('spec/fixtures/pull_requests.json'), headers: { 'Content-Type' => 'application/json' })
-        stub_request(:get, 'https://api.github.com/search/issues?per_page=100&q=is:pr+user:alphagov+state:open+author:app/dependabot+review:changes_requested')
+        stub_request(:get, 'https://api.github.com/search/issues?per_page=100&q=is:pr+user:alphagov+state:open+author:app/dependabot-preview+review:changes_requested')
           .to_return(body: '{ "total_count": 0, "incomplete_results": false, "items": [] }', headers: { 'Content-Type' => 'application/json' })
       end
 
@@ -76,11 +76,11 @@ describe GovukDependencies do
 
     context 'given no open pull requests' do
       before do
-        stub_request(:get, 'https://api.github.com/search/issues?per_page=100&q=is:pr+user:alphagov+state:open+author:app/dependabot+review:approved')
+        stub_request(:get, 'https://api.github.com/search/issues?per_page=100&q=is:pr+user:alphagov+state:open+author:app/dependabot-preview+review:approved')
           .to_return(body: '{ "total_count": 0, "incomplete_results": false, "items": [] }', headers: { 'Content-Type' => 'application/json' })
-        stub_request(:get, 'https://api.github.com/search/issues?per_page=100&q=is:pr+user:alphagov+state:open+author:app/dependabot+review:required')
+        stub_request(:get, 'https://api.github.com/search/issues?per_page=100&q=is:pr+user:alphagov+state:open+author:app/dependabot-preview+review:required')
           .to_return(body: '{ "total_count": 0, "incomplete_results": false, "items": [] }', headers: { 'Content-Type' => 'application/json' })
-        stub_request(:get, 'https://api.github.com/search/issues?per_page=100&q=is:pr+user:alphagov+state:open+author:app/dependabot+review:changes_requested')
+        stub_request(:get, 'https://api.github.com/search/issues?per_page=100&q=is:pr+user:alphagov+state:open+author:app/dependabot-preview+review:changes_requested')
           .to_return(body: '{ "total_count": 0, "incomplete_results": false, "items": [] }', headers: { 'Content-Type' => 'application/json' })
       end
 
@@ -119,11 +119,11 @@ describe GovukDependencies do
 
     context 'given pull requests that require review' do
       before do
-        stub_request(:get, 'https://api.github.com/search/issues?per_page=100&q=is:pr+user:alphagov+state:open+author:app/dependabot+review:approved')
+        stub_request(:get, 'https://api.github.com/search/issues?per_page=100&q=is:pr+user:alphagov+state:open+author:app/dependabot-preview+review:approved')
           .to_return(body: '{ "total_count": 0, "incomplete_results": false, "items": [] }', headers: { 'Content-Type' => 'application/json' })
-        stub_request(:get, 'https://api.github.com/search/issues?per_page=100&q=is:pr+user:alphagov+state:open+author:app/dependabot+review:required')
+        stub_request(:get, 'https://api.github.com/search/issues?per_page=100&q=is:pr+user:alphagov+state:open+author:app/dependabot-preview+review:required')
           .to_return(body: File.read('spec/fixtures/pull_requests.json'), headers: { 'Content-Type' => 'application/json' })
-        stub_request(:get, 'https://api.github.com/search/issues?per_page=100&q=is:pr+user:alphagov+state:open+author:app/dependabot+review:changes_requested')
+        stub_request(:get, 'https://api.github.com/search/issues?per_page=100&q=is:pr+user:alphagov+state:open+author:app/dependabot-preview+review:changes_requested')
           .to_return(body: '{ "total_count": 0, "incomplete_results": false, "items": [] }', headers: { 'Content-Type' => 'application/json' })
       end
 
@@ -148,11 +148,11 @@ describe GovukDependencies do
 
     context 'given open approved pull requests' do
       before do
-        stub_request(:get, 'https://api.github.com/search/issues?per_page=100&q=is:pr+user:alphagov+state:open+author:app/dependabot+review:approved')
+        stub_request(:get, 'https://api.github.com/search/issues?per_page=100&q=is:pr+user:alphagov+state:open+author:app/dependabot-preview+review:approved')
           .to_return(body: File.read('spec/fixtures/pull_requests.json'), headers: { 'Content-Type' => 'application/json' })
-        stub_request(:get, 'https://api.github.com/search/issues?per_page=100&q=is:pr+user:alphagov+state:open+author:app/dependabot+review:required')
+        stub_request(:get, 'https://api.github.com/search/issues?per_page=100&q=is:pr+user:alphagov+state:open+author:app/dependabot-preview+review:required')
           .to_return(body: '{ "total_count": 0, "incomplete_results": false, "items": [] }', headers: { 'Content-Type' => 'application/json' })
-        stub_request(:get, 'https://api.github.com/search/issues?per_page=100&q=is:pr+user:alphagov+state:open+author:app/dependabot+review:changes_requested')
+        stub_request(:get, 'https://api.github.com/search/issues?per_page=100&q=is:pr+user:alphagov+state:open+author:app/dependabot-preview+review:changes_requested')
           .to_return(body: '{ "total_count": 0, "incomplete_results": false, "items": [] }', headers: { 'Content-Type' => 'application/json' })
       end
 
@@ -177,11 +177,11 @@ describe GovukDependencies do
 
     context 'given pull requests that have changes requested' do
       before do
-        stub_request(:get, 'https://api.github.com/search/issues?per_page=100&q=is:pr+user:alphagov+state:open+author:app/dependabot+review:approved')
+        stub_request(:get, 'https://api.github.com/search/issues?per_page=100&q=is:pr+user:alphagov+state:open+author:app/dependabot-preview+review:approved')
           .to_return(body: '{ "total_count": 0, "incomplete_results": false, "items": [] }', headers: { 'Content-Type' => 'application/json' })
-        stub_request(:get, 'https://api.github.com/search/issues?per_page=100&q=is:pr+user:alphagov+state:open+author:app/dependabot+review:required')
+        stub_request(:get, 'https://api.github.com/search/issues?per_page=100&q=is:pr+user:alphagov+state:open+author:app/dependabot-preview+review:required')
           .to_return(body: '{ "total_count": 0, "incomplete_results": false, "items": [] }', headers: { 'Content-Type' => 'application/json' })
-        stub_request(:get, 'https://api.github.com/search/issues?per_page=100&q=is:pr+user:alphagov+state:open+author:app/dependabot+review:changes_requested')
+        stub_request(:get, 'https://api.github.com/search/issues?per_page=100&q=is:pr+user:alphagov+state:open+author:app/dependabot-preview+review:changes_requested')
           .to_return(body: File.read('spec/fixtures/pull_requests.json'), headers: { 'Content-Type' => 'application/json' })
       end
 
@@ -207,11 +207,11 @@ describe GovukDependencies do
 
   context 'Slack' do
     before do
-      stub_request(:get, 'https://api.github.com/search/issues?per_page=100&q=is:pr+user:alphagov+state:open+author:app/dependabot+review:approved')
+      stub_request(:get, 'https://api.github.com/search/issues?per_page=100&q=is:pr+user:alphagov+state:open+author:app/dependabot-preview+review:approved')
         .to_return(body: '{ "total_count": 0, "incomplete_results": false, "items": [] }', headers: { 'Content-Type' => 'application/json' })
-      stub_request(:get, 'https://api.github.com/search/issues?per_page=100&q=is:pr+user:alphagov+state:open+author:app/dependabot+review:required')
+      stub_request(:get, 'https://api.github.com/search/issues?per_page=100&q=is:pr+user:alphagov+state:open+author:app/dependabot-preview+review:required')
         .to_return(body: File.read('spec/fixtures/pull_requests.json'), headers: { 'Content-Type' => 'application/json' })
-      stub_request(:get, 'https://api.github.com/search/issues?per_page=100&q=is:pr+user:alphagov+state:open+author:app/dependabot+review:changes_requested')
+      stub_request(:get, 'https://api.github.com/search/issues?per_page=100&q=is:pr+user:alphagov+state:open+author:app/dependabot-preview+review:changes_requested')
         .to_return(body: '{ "total_count": 0, "incomplete_results": false, "items": [] }', headers: { 'Content-Type' => 'application/json' })
       stub_request(:get, "https://docs.publishing.service.gov.uk/apps.json")
         .to_return(
@@ -239,7 +239,7 @@ describe GovukDependencies do
 
   context 'Stats page' do
     before do
-      stub_request(:get, "https://api.github.com/search/issues?q=is:pr%20user:alphagov%20author:app/dependabot")
+      stub_request(:get, "https://api.github.com/search/issues?q=is:pr%20user:alphagov%20author:app/dependabot-preview")
         .to_return(body: File.open('spec/fixtures/pull_requests.json'), headers: { 'Content-Type' => 'application/json' })
     end
 

--- a/spec/acceptance/dependapanda_spec.rb
+++ b/spec/acceptance/dependapanda_spec.rb
@@ -12,11 +12,11 @@ describe Dependapanda do
   before do
     ENV['SLACK_WEBHOOK_URL'] = 'http://example.com/webhook'
 
-    stub_request(:get, 'https://api.github.com/search/issues?per_page=100&q=is:pr+user:alphagov+state:open+author:app/dependabot+review:approved')
+    stub_request(:get, 'https://api.github.com/search/issues?per_page=100&q=is:pr+user:alphagov+state:open+author:app/dependabot-preview+review:approved')
       .to_return(body: '{ "total_count": 0, "incomplete_results": false, "items": [] }', headers: { 'Content-Type' => 'application/json' })
-    stub_request(:get, 'https://api.github.com/search/issues?per_page=100&q=is:pr+user:alphagov+state:open+author:app/dependabot+review:required')
+    stub_request(:get, 'https://api.github.com/search/issues?per_page=100&q=is:pr+user:alphagov+state:open+author:app/dependabot-preview+review:required')
       .to_return(body: File.read('spec/fixtures/pull_requests.json'), headers: { 'Content-Type' => 'application/json' })
-    stub_request(:get, 'https://api.github.com/search/issues?per_page=100&q=is:pr+user:alphagov+state:open+author:app/dependabot+review:changes_requested')
+    stub_request(:get, 'https://api.github.com/search/issues?per_page=100&q=is:pr+user:alphagov+state:open+author:app/dependabot-preview+review:changes_requested')
       .to_return(body: '{ "total_count": 0, "incomplete_results": false, "items": [] }', headers: { 'Content-Type' => 'application/json' })
 
     stub_request(:get, "https://docs.publishing.service.gov.uk/apps.json")
@@ -48,11 +48,11 @@ describe Dependapanda do
   context 'Full Message' do
     it 'sends all the pull requests in the message' do
       modelling_services_payload = {
-        'payload' => '{"channel":"modelling-services","username":"Dependapanda","icon_emoji":":panda_face:","text":"<https://govuk-dependencies.herokuapp.com/team/modelling-services|modelling-services> have 2 Dependabot PRs open on the following apps:\n\n<https://github.com/alphagov/publisher/pulls/app/dependabot|publisher> (2)"}'
+        'payload' => '{"channel":"modelling-services","username":"Dependapanda","icon_emoji":":panda_face:","text":"<https://govuk-dependencies.herokuapp.com/team/modelling-services|modelling-services> have 2 Dependabot PRs open on the following apps:\n\n<https://github.com/alphagov/publisher/pulls/app/dependabot-preview|publisher> (2)"}'
       }
 
       start_pages_payload = {
-        'payload' => '{"channel":"start-pages","username":"Dependapanda","icon_emoji":":panda_face:","text":"<https://govuk-dependencies.herokuapp.com/team/start-pages|start-pages> have 1 Dependabot PRs open on the following apps:\n\n<https://github.com/alphagov/frontend/pulls/app/dependabot|frontend> (1)"}'
+        'payload' => '{"channel":"start-pages","username":"Dependapanda","icon_emoji":":panda_face:","text":"<https://govuk-dependencies.herokuapp.com/team/start-pages|start-pages> have 1 Dependabot PRs open on the following apps:\n\n<https://github.com/alphagov/frontend/pulls/app/dependabot-preview|frontend> (1)"}'
       }
 
       described_class.new.send_full_message

--- a/spec/gateways/pull_request_count_spec.rb
+++ b/spec/gateways/pull_request_count_spec.rb
@@ -1,7 +1,7 @@
 describe Gateways::PullRequestCount do
   context 'when getting all PRs for dependabot' do
     before do
-      stub_request(:get, "https://api.github.com/search/issues?q=is:pr%20user:alphagov%20author:app/dependabot")
+      stub_request(:get, "https://api.github.com/search/issues?q=is:pr%20user:alphagov%20author:app/dependabot-preview")
         .to_return(body: File.open('spec/fixtures/pull_requests.json'), headers: { 'Content-Type' => 'application/json' })
     end
     it 'returns the total count' do

--- a/spec/gateways/pull_request_spec.rb
+++ b/spec/gateways/pull_request_spec.rb
@@ -1,7 +1,7 @@
 describe Gateways::PullRequest do
-  REVIEW_REQUIRED_URL = 'https://api.github.com/search/issues?per_page=100&q=is:pr+user:alphagov+state:open+author:app/dependabot+review:required'.freeze
-  APPROVED_URL = 'https://api.github.com/search/issues?per_page=100&q=is:pr+user:alphagov+state:open+author:app/dependabot+review:approved'.freeze
-  CHANGES_REQUESTED_URL = 'https://api.github.com/search/issues?per_page=100&q=is:pr+user:alphagov+state:open+author:app/dependabot+review:changes_requested'.freeze
+  REVIEW_REQUIRED_URL = 'https://api.github.com/search/issues?per_page=100&q=is:pr+user:alphagov+state:open+author:app/dependabot-preview+review:required'.freeze
+  APPROVED_URL = 'https://api.github.com/search/issues?per_page=100&q=is:pr+user:alphagov+state:open+author:app/dependabot-preview+review:approved'.freeze
+  CHANGES_REQUESTED_URL = 'https://api.github.com/search/issues?per_page=100&q=is:pr+user:alphagov+state:open+author:app/dependabot-preview+review:changes_requested'.freeze
   NO_PULL_REQUESTS_BODY = '{ "total_count": 0, "incomplete_results": false, "items": [] }'.freeze
 
   around do |example|

--- a/spec/presenters/slack/full_message_spec.rb
+++ b/spec/presenters/slack/full_message_spec.rb
@@ -6,7 +6,7 @@ describe Presenters::Slack::FullMessage do
         applications: [
           {
             application_name: 'content-tagger',
-            application_url: 'https://github.com/alphagov/content-tagger/app/dependabot',
+            application_url: 'https://github.com/alphagov/content-tagger/app/dependabot-preview',
             pull_request_count: 1
           }
         ]
@@ -16,7 +16,7 @@ describe Presenters::Slack::FullMessage do
 
       expect(result).to eq('<https://govuk-dependencies.herokuapp.com/team/email|email> have 1 Dependabot PRs open on the following apps:
 
-<https://github.com/alphagov/content-tagger/pulls/app/dependabot|content-tagger> (1)')
+<https://github.com/alphagov/content-tagger/pulls/app/dependabot-preview|content-tagger> (1)')
     end
   end
 
@@ -27,11 +27,11 @@ describe Presenters::Slack::FullMessage do
         applications: [
           {
             application_name: 'collections-publisher',
-            application_url: 'https://github.com/alphagov/content-publisher/app/dependabot',
+            application_url: 'https://github.com/alphagov/content-publisher/app/dependabot-preview',
             pull_request_count: 1
           }, {
             application_name: 'content-tagger',
-            application_url: 'https://github.com/alphagov/content-tagger/app/dependabot',
+            application_url: 'https://github.com/alphagov/content-tagger/app/dependabot-preview',
             pull_request_count: 1
           }
         ]
@@ -41,7 +41,7 @@ describe Presenters::Slack::FullMessage do
 
       expect(result).to eq('<https://govuk-dependencies.herokuapp.com/team/taxonomy|taxonomy> have 2 Dependabot PRs open on the following apps:
 
-<https://github.com/alphagov/collections-publisher/pulls/app/dependabot|collections-publisher> (1) <https://github.com/alphagov/content-tagger/pulls/app/dependabot|content-tagger> (1)')
+<https://github.com/alphagov/collections-publisher/pulls/app/dependabot-preview|collections-publisher> (1) <https://github.com/alphagov/content-tagger/pulls/app/dependabot-preview|content-tagger> (1)')
     end
 
     it 'groups by application' do
@@ -50,11 +50,11 @@ describe Presenters::Slack::FullMessage do
         applications: [
           {
             application_name: 'collections-publisher',
-            application_url: 'https://github.com/alphagov/content-publisher/app/dependabot',
+            application_url: 'https://github.com/alphagov/content-publisher/app/dependabot-preview',
             pull_request_count: 1
           }, {
             application_name: 'content-tagger',
-            application_url: 'https://github.com/alphagov/content-tagger/app/dependabot',
+            application_url: 'https://github.com/alphagov/content-tagger/app/dependabot-preview',
             pull_request_count: 2
           }
         ]
@@ -64,7 +64,7 @@ describe Presenters::Slack::FullMessage do
 
       expect(result).to eq('<https://govuk-dependencies.herokuapp.com/team/taxonomy|taxonomy> have 3 Dependabot PRs open on the following apps:
 
-<https://github.com/alphagov/collections-publisher/pulls/app/dependabot|collections-publisher> (1) <https://github.com/alphagov/content-tagger/pulls/app/dependabot|content-tagger> (2)')
+<https://github.com/alphagov/collections-publisher/pulls/app/dependabot-preview|collections-publisher> (1) <https://github.com/alphagov/content-tagger/pulls/app/dependabot-preview|content-tagger> (2)')
     end
   end
 end

--- a/spec/presenters/slack/simple_message_spec.rb
+++ b/spec/presenters/slack/simple_message_spec.rb
@@ -6,7 +6,7 @@ describe Presenters::Slack::SimpleMessage do
         applications: [
           {
             application_name: 'content-tagger',
-            application_url: 'https://github.com/alphagov/content-tagger/app/dependabot',
+            application_url: 'https://github.com/alphagov/content-tagger/app/dependabot-preview',
             pull_request_count: 1
           }
         ]

--- a/spec/use_cases/group/applications_by_team_spec.rb
+++ b/spec/use_cases/group/applications_by_team_spec.rb
@@ -30,7 +30,7 @@ describe UseCases::Group::ApplicationsByTeam do
             {
               application_name: 'some-application',
               application_url:
-              'https://github.com/alphagov/some-application/pulls/app/dependabot',
+              'https://github.com/alphagov/some-application/pulls/app/dependabot-preview',
               pull_request_count: 1
             }
           ]
@@ -76,7 +76,7 @@ describe UseCases::Group::ApplicationsByTeam do
             {
               application_name: 'collections',
               application_url:
-              'https://github.com/alphagov/collections/pulls/app/dependabot',
+              'https://github.com/alphagov/collections/pulls/app/dependabot-preview',
               pull_request_count: 1
             }
           ]
@@ -87,7 +87,7 @@ describe UseCases::Group::ApplicationsByTeam do
             {
               application_name: 'collections-publisher',
               application_url:
-              'https://github.com/alphagov/collections-publisher/pulls/app/dependabot',
+              'https://github.com/alphagov/collections-publisher/pulls/app/dependabot-preview',
               pull_request_count: 1
             }
           ]
@@ -129,7 +129,7 @@ describe UseCases::Group::ApplicationsByTeam do
             {
               application_name: 'collections',
               application_url:
-              'https://github.com/alphagov/collections/pulls/app/dependabot',
+              'https://github.com/alphagov/collections/pulls/app/dependabot-preview',
               pull_request_count: 2
             }
           ]


### PR DESCRIPTION
Github recently acquired Dependabot and the app was renamed so this app
stopped working. This PR should fix that.

https://dependabot.com/blog/hello-github/#what-is-happening-to-the-existing-dependabot-product