### PR TITLE
Add application overflow distribution

### DIFF
--- a/lib/use_cases/distribute/overflow_to_developers_channel.rb
+++ b/lib/use_cases/distribute/overflow_to_developers_channel.rb
@@ -1,0 +1,44 @@
+module UseCases
+  module Distribute
+    class OverflowToDevelopersChannel
+      def execute(application_prs_by_team:, overflow_at: 15)
+        @application_prs_by_team = application_prs_by_team
+        @overflow_at = overflow_at
+
+        redistribution = []
+
+        application_prs_by_team.each do |application_prs_for_team|
+          redistribution.concat(redistribute(application_prs_for_team[:applications]))
+        end
+
+        if redistribution.any?
+          ensure_govuk_developers_exists
+          govuk_developers_application_prs[:applications].concat(redistribution)
+        end
+
+        application_prs_by_team
+      end
+
+    private
+
+      attr_reader :application_prs_by_team, :overflow_at
+
+      def ensure_govuk_developers_exists
+        unless govuk_developers_application_prs
+          application_prs_by_team << { team_name: "govuk-developers", applications: [] }
+        end
+      end
+
+      def redistribute(applications_with_prs)
+        return [] if applications_with_prs.count <= overflow_at
+
+        number_of_apps = applications_with_prs.count
+        applications_with_prs.pop(number_of_apps - overflow_at)
+      end
+
+      def govuk_developers_application_prs
+        application_prs_by_team.find { |h| h[:team_name] == "govuk-developers" }
+      end
+    end
+  end
+end

--- a/lib/use_cases/slack/send_messages.rb
+++ b/lib/use_cases/slack/send_messages.rb
@@ -7,6 +7,7 @@ module UseCases
         pull_request_usecase: UseCases::PullRequests::Fetch.new,
         group_applications_by_team_usecase: UseCases::Group::ApplicationsByTeam.new,
         scheduler: UseCases::Slack::Schedulers::EveryDay.new,
+        distributor: UseCases::Distribute::OverflowToDevelopersChannel.new,
         message_presenter:
       )
 
@@ -16,6 +17,7 @@ module UseCases
         @pull_request_usecase = pull_request_usecase
         @message_presenter = message_presenter
         @group_applications_by_team_usecase = group_applications_by_team_usecase
+        @distributor = distributor
       end
 
       def execute(team: nil)
@@ -31,7 +33,8 @@ module UseCases
                   :pull_request_usecase,
                   :message_presenter,
                   :scheduler,
-                  :group_applications_by_team_usecase
+                  :group_applications_by_team_usecase,
+                  :distributor
 
       def send_messages(applications_by_teams)
         applications_by_teams.each do |applications_by_team|
@@ -50,7 +53,7 @@ module UseCases
       end
 
       def scoped_by_team(pull_requests, team)
-        return pull_requests if team.nil?
+        return distributor.execute(application_prs_by_team: pull_requests) if team.nil?
 
         pull_requests.select { |pr| pr[:team_name] == team }
       end

--- a/spec/use_cases/distribute/overflow_to_developers_channel_spec.rb
+++ b/spec/use_cases/distribute/overflow_to_developers_channel_spec.rb
@@ -1,0 +1,119 @@
+require "spec_helper"
+
+describe UseCases::Distribute::OverflowToDevelopersChannel do
+  let(:prs_by_team) {
+    [
+      {
+        team_name: "govuk-platform-health",
+        applications:
+          [
+            { application_name: "whitehall", pull_request_count: 5 },
+            { application_name: "signon", pull_request_count: 4 },
+            { application_name: "ckanext-datagovuk", pull_request_count: 3 },
+            { application_name: "collections-publisher", pull_request_count: 2 },
+            { application_name: "content-data-admin", pull_request_count: 1 },
+            { application_name: "content-publisher", pull_request_count: 1 },
+            { application_name: "support", pull_request_count: 1 },
+          ],
+      },
+      {
+        team_name: "govuk-top-team",
+        applications:
+          [
+            { application_name: "not-another-whitehall", pull_request_count: 1 },
+          ],
+      },
+    ]
+  }
+
+  RSpec::Matchers.define :have_application_count_for_team do |expected, team_name|
+    def number_of_apps(teams, team_name)
+      teams.inject(0) do |sum, team_and_apps|
+        sum = team_and_apps[:applications].count if team_and_apps[:team_name] == team_name
+        sum
+      end
+    end
+    match do |actual|
+      expected == number_of_apps(actual, team_name)
+    end
+    failure_message do |actual|
+      "expected #{team_name} to have #{expected} application(s) but it actually has #{number_of_apps(actual, team_name)}"
+    end
+  end
+
+  def distribute(prs, overflow_at)
+    UseCases::Distribute::OverflowToDevelopersChannel.new.execute(
+      application_prs_by_team: prs,
+      overflow_at: overflow_at,
+    )
+  end
+
+  context "when there is no overflow for a team" do
+    let(:no_overflow) {
+      distribute(prs_by_team, 10)
+    }
+
+    it "should not create the govuk-developers team" do
+      expect(no_overflow).not_to satisfy("contain a team name govuk-developers") do |v|
+        v.any? do |team_application_hash|
+          team_application_hash[:team_name] == "govuk-developers"
+        end
+      end
+    end
+
+    it "should not redistribute any apps" do
+      expect(no_overflow).to have_application_count_for_team(7, "govuk-platform-health")
+    end
+  end
+
+  context "when there is overflow for a team" do
+    let(:overflow) {
+      distribute(prs_by_team, 5)
+    }
+
+    it "should create the govuk-developers team" do
+      expect(overflow).to satisfy("contain a team name govuk-developers") do |v|
+        v.any? do |team_application_hash|
+          team_application_hash[:team_name] == "govuk-developers"
+        end
+      end
+    end
+
+    it "should assign the overflow to govuk-developers" do
+      expect(overflow).to have_application_count_for_team(5, "govuk-platform-health")
+      expect(overflow).to have_application_count_for_team(2, "govuk-developers")
+      expect(overflow).to have_application_count_for_team(1, "govuk-top-team")
+    end
+  end
+
+  context "when govuk-developers team already exists" do
+    let(:extra_team) {
+      [
+        {
+          team_name: "govuk-developers",
+          applications:
+          [
+            { application_name: "sardines", pull_request_count: 3 },
+            { application_name: "smoked-salmon", pull_request_count: 2 },
+            { application_name: "chopped-liver", pull_request_count: 2 },
+            { application_name: "pickled-herring", pull_request_count: 2 },
+          ],
+        },
+      ]
+    }
+
+    let(:overflow_with_dev_team) {
+      distribute(prs_by_team + extra_team, 5)
+    }
+
+    it "should not create a second govuk-developers team" do
+      number_of_govuk_developers_teams = overflow_with_dev_team.count { |h| h[:team_name] == "govuk-developers" }
+
+      expect(number_of_govuk_developers_teams).to eq(1)
+    end
+
+    it "should append the overflow to govuk-developers" do
+      expect(overflow_with_dev_team).to have_application_count_for_team(6, "govuk-developers")
+    end
+  end
+end


### PR DESCRIPTION
To help distribute Dependabot PRs a little more fairly around the
GOV.UK developer community, we want to be able to move some overflow
from teams into the general #govuk-developers channel.

Add a use case to distribute applications when a team has more than a defined overflow (set at a default of 15). This means when #platform-health has pull requests for more than 15 applications, the overflow (or application.count -15) will be distributed to the #govuk-developers channel instead of #platform-health.

Tap into the use case when sending slack messages.

This is not a very clever algorithm, but it's an experiment.