### PR TITLE
Also search for PRs under dependabot

### DIFF
--- a/lib/gateways/pull_request.rb
+++ b/lib/gateways/pull_request.rb
@@ -13,17 +13,17 @@ module Gateways
   private
 
     def approved_pull_requests
-      approved_pull_requests = @octokit.search_issues("is:pr user:alphagov state:open author:app/dependabot-preview review:approved").items
+      approved_pull_requests = @octokit.search_issues("is:pr user:alphagov state:open author:app/dependabot author:app/dependabot-preview review:approved").items
       build_pull_requests(approved_pull_requests, "approved")
     end
 
     def review_required_pull_requests
-      review_required_pull_requests = @octokit.search_issues("is:pr user:alphagov state:open author:app/dependabot-preview review:required").items
+      review_required_pull_requests = @octokit.search_issues("is:pr user:alphagov state:open author:app/dependabot author:app/dependabot-preview review:required").items
       build_pull_requests(review_required_pull_requests, "review required")
     end
 
     def changes_requested_pull_requests
-      changes_requested_pull_requests = @octokit.search_issues("is:pr user:alphagov state:open author:app/dependabot-preview review:changes_requested").items
+      changes_requested_pull_requests = @octokit.search_issues("is:pr user:alphagov state:open author:app/dependabot author:app/dependabot-preview review:changes_requested").items
       build_pull_requests(changes_requested_pull_requests, "changes requested")
     end
 

--- a/lib/gateways/pull_request_count.rb
+++ b/lib/gateways/pull_request_count.rb
@@ -5,7 +5,7 @@ module Gateways
     end
 
     def execute
-      @octokit.search_issues("is:pr user:alphagov author:app/dependabot-preview").total_count
+      @octokit.search_issues("is:pr user:alphagov author:app/dependabot author:app/dependabot-preview").total_count
     end
   end
 end

--- a/spec/acceptance/app_spec.rb
+++ b/spec/acceptance/app_spec.rb
@@ -19,11 +19,11 @@ describe GovukDependencies do
   context "Dashboard" do
     context "given open pull requests" do
       before do
-        stub_request(:get, "https://api.github.com/search/issues?per_page=100&q=is:pr+user:alphagov+state:open+author:app/dependabot-preview+review:approved")
+        stub_request(:get, "https://api.github.com/search/issues?per_page=100&q=is:pr+user:alphagov+state:open+author:app/dependabot+author:app/dependabot-preview+review:approved")
           .to_return(body: '{ "total_count": 0, "incomplete_results": false, "items": [] }', headers: { "Content-Type" => "application/json" })
-        stub_request(:get, "https://api.github.com/search/issues?per_page=100&q=is:pr+user:alphagov+state:open+author:app/dependabot-preview+review:required")
+        stub_request(:get, "https://api.github.com/search/issues?per_page=100&q=is:pr+user:alphagov+state:open+author:app/dependabot+author:app/dependabot-preview+review:required")
           .to_return(body: File.read("spec/fixtures/pull_requests.json"), headers: { "Content-Type" => "application/json" })
-        stub_request(:get, "https://api.github.com/search/issues?per_page=100&q=is:pr+user:alphagov+state:open+author:app/dependabot-preview+review:changes_requested")
+        stub_request(:get, "https://api.github.com/search/issues?per_page=100&q=is:pr+user:alphagov+state:open+author:app/dependabot+author:app/dependabot-preview+review:changes_requested")
           .to_return(body: '{ "total_count": 0, "incomplete_results": false, "items": [] }', headers: { "Content-Type" => "application/json" })
       end
 
@@ -76,11 +76,11 @@ describe GovukDependencies do
 
     context "given no open pull requests" do
       before do
-        stub_request(:get, "https://api.github.com/search/issues?per_page=100&q=is:pr+user:alphagov+state:open+author:app/dependabot-preview+review:approved")
+        stub_request(:get, "https://api.github.com/search/issues?per_page=100&q=is:pr+user:alphagov+state:open+author:app/dependabot+author:app/dependabot-preview+review:approved")
           .to_return(body: '{ "total_count": 0, "incomplete_results": false, "items": [] }', headers: { "Content-Type" => "application/json" })
-        stub_request(:get, "https://api.github.com/search/issues?per_page=100&q=is:pr+user:alphagov+state:open+author:app/dependabot-preview+review:required")
+        stub_request(:get, "https://api.github.com/search/issues?per_page=100&q=is:pr+user:alphagov+state:open+author:app/dependabot+author:app/dependabot-preview+review:required")
           .to_return(body: '{ "total_count": 0, "incomplete_results": false, "items": [] }', headers: { "Content-Type" => "application/json" })
-        stub_request(:get, "https://api.github.com/search/issues?per_page=100&q=is:pr+user:alphagov+state:open+author:app/dependabot-preview+review:changes_requested")
+        stub_request(:get, "https://api.github.com/search/issues?per_page=100&q=is:pr+user:alphagov+state:open+author:app/dependabot+author:app/dependabot-preview+review:changes_requested")
           .to_return(body: '{ "total_count": 0, "incomplete_results": false, "items": [] }', headers: { "Content-Type" => "application/json" })
       end
 
@@ -119,11 +119,11 @@ describe GovukDependencies do
 
     context "given pull requests that require review" do
       before do
-        stub_request(:get, "https://api.github.com/search/issues?per_page=100&q=is:pr+user:alphagov+state:open+author:app/dependabot-preview+review:approved")
+        stub_request(:get, "https://api.github.com/search/issues?per_page=100&q=is:pr+user:alphagov+state:open+author:app/dependabot+author:app/dependabot-preview+review:approved")
           .to_return(body: '{ "total_count": 0, "incomplete_results": false, "items": [] }', headers: { "Content-Type" => "application/json" })
-        stub_request(:get, "https://api.github.com/search/issues?per_page=100&q=is:pr+user:alphagov+state:open+author:app/dependabot-preview+review:required")
+        stub_request(:get, "https://api.github.com/search/issues?per_page=100&q=is:pr+user:alphagov+state:open+author:app/dependabot+author:app/dependabot-preview+review:required")
           .to_return(body: File.read("spec/fixtures/pull_requests.json"), headers: { "Content-Type" => "application/json" })
-        stub_request(:get, "https://api.github.com/search/issues?per_page=100&q=is:pr+user:alphagov+state:open+author:app/dependabot-preview+review:changes_requested")
+        stub_request(:get, "https://api.github.com/search/issues?per_page=100&q=is:pr+user:alphagov+state:open+author:app/dependabot+author:app/dependabot-preview+review:changes_requested")
           .to_return(body: '{ "total_count": 0, "incomplete_results": false, "items": [] }', headers: { "Content-Type" => "application/json" })
       end
 
@@ -148,11 +148,11 @@ describe GovukDependencies do
 
     context "given open approved pull requests" do
       before do
-        stub_request(:get, "https://api.github.com/search/issues?per_page=100&q=is:pr+user:alphagov+state:open+author:app/dependabot-preview+review:approved")
+        stub_request(:get, "https://api.github.com/search/issues?per_page=100&q=is:pr+user:alphagov+state:open+author:app/dependabot+author:app/dependabot-preview+review:approved")
           .to_return(body: File.read("spec/fixtures/pull_requests.json"), headers: { "Content-Type" => "application/json" })
-        stub_request(:get, "https://api.github.com/search/issues?per_page=100&q=is:pr+user:alphagov+state:open+author:app/dependabot-preview+review:required")
+        stub_request(:get, "https://api.github.com/search/issues?per_page=100&q=is:pr+user:alphagov+state:open+author:app/dependabot+author:app/dependabot-preview+review:required")
           .to_return(body: '{ "total_count": 0, "incomplete_results": false, "items": [] }', headers: { "Content-Type" => "application/json" })
-        stub_request(:get, "https://api.github.com/search/issues?per_page=100&q=is:pr+user:alphagov+state:open+author:app/dependabot-preview+review:changes_requested")
+        stub_request(:get, "https://api.github.com/search/issues?per_page=100&q=is:pr+user:alphagov+state:open+author:app/dependabot+author:app/dependabot-preview+review:changes_requested")
           .to_return(body: '{ "total_count": 0, "incomplete_results": false, "items": [] }', headers: { "Content-Type" => "application/json" })
       end
 
@@ -177,11 +177,11 @@ describe GovukDependencies do
 
     context "given pull requests that have changes requested" do
       before do
-        stub_request(:get, "https://api.github.com/search/issues?per_page=100&q=is:pr+user:alphagov+state:open+author:app/dependabot-preview+review:approved")
+        stub_request(:get, "https://api.github.com/search/issues?per_page=100&q=is:pr+user:alphagov+state:open+author:app/dependabot+author:app/dependabot-preview+review:approved")
           .to_return(body: '{ "total_count": 0, "incomplete_results": false, "items": [] }', headers: { "Content-Type" => "application/json" })
-        stub_request(:get, "https://api.github.com/search/issues?per_page=100&q=is:pr+user:alphagov+state:open+author:app/dependabot-preview+review:required")
+        stub_request(:get, "https://api.github.com/search/issues?per_page=100&q=is:pr+user:alphagov+state:open+author:app/dependabot+author:app/dependabot-preview+review:required")
           .to_return(body: '{ "total_count": 0, "incomplete_results": false, "items": [] }', headers: { "Content-Type" => "application/json" })
-        stub_request(:get, "https://api.github.com/search/issues?per_page=100&q=is:pr+user:alphagov+state:open+author:app/dependabot-preview+review:changes_requested")
+        stub_request(:get, "https://api.github.com/search/issues?per_page=100&q=is:pr+user:alphagov+state:open+author:app/dependabot+author:app/dependabot-preview+review:changes_requested")
           .to_return(body: File.read("spec/fixtures/pull_requests.json"), headers: { "Content-Type" => "application/json" })
       end
 
@@ -207,11 +207,11 @@ describe GovukDependencies do
 
   context "Slack" do
     before do
-      stub_request(:get, "https://api.github.com/search/issues?per_page=100&q=is:pr+user:alphagov+state:open+author:app/dependabot-preview+review:approved")
+      stub_request(:get, "https://api.github.com/search/issues?per_page=100&q=is:pr+user:alphagov+state:open+author:app/dependabot+author:app/dependabot-preview+review:approved")
         .to_return(body: '{ "total_count": 0, "incomplete_results": false, "items": [] }', headers: { "Content-Type" => "application/json" })
-      stub_request(:get, "https://api.github.com/search/issues?per_page=100&q=is:pr+user:alphagov+state:open+author:app/dependabot-preview+review:required")
+      stub_request(:get, "https://api.github.com/search/issues?per_page=100&q=is:pr+user:alphagov+state:open+author:app/dependabot+author:app/dependabot-preview+review:required")
         .to_return(body: File.read("spec/fixtures/pull_requests.json"), headers: { "Content-Type" => "application/json" })
-      stub_request(:get, "https://api.github.com/search/issues?per_page=100&q=is:pr+user:alphagov+state:open+author:app/dependabot-preview+review:changes_requested")
+      stub_request(:get, "https://api.github.com/search/issues?per_page=100&q=is:pr+user:alphagov+state:open+author:app/dependabot+author:app/dependabot-preview+review:changes_requested")
         .to_return(body: '{ "total_count": 0, "incomplete_results": false, "items": [] }', headers: { "Content-Type" => "application/json" })
       stub_request(:get, "https://docs.publishing.service.gov.uk/apps.json")
         .to_return(
@@ -239,7 +239,7 @@ describe GovukDependencies do
 
   context "Stats page" do
     before do
-      stub_request(:get, "https://api.github.com/search/issues?q=is:pr%20user:alphagov%20author:app/dependabot-preview")
+      stub_request(:get, "https://api.github.com/search/issues?q=is:pr%20user:alphagov%20author:app/dependabot%20author:app/dependabot-preview")
         .to_return(body: File.open("spec/fixtures/pull_requests.json"), headers: { "Content-Type" => "application/json" })
     end
 

--- a/spec/acceptance/dependapanda_spec.rb
+++ b/spec/acceptance/dependapanda_spec.rb
@@ -14,11 +14,11 @@ describe Dependapanda do
   before do
     ENV["SLACK_WEBHOOK_URL"] = "http://example.com/webhook"
 
-    stub_request(:get, "https://api.github.com/search/issues?per_page=100&q=is:pr+user:alphagov+state:open+author:app/dependabot-preview+review:approved")
+    stub_request(:get, "https://api.github.com/search/issues?per_page=100&q=is:pr+user:alphagov+state:open+author:app/dependabot+author:app/dependabot-preview+review:approved")
       .to_return(body: '{ "total_count": 0, "incomplete_results": false, "items": [] }', headers: { "Content-Type" => "application/json" })
-    stub_request(:get, "https://api.github.com/search/issues?per_page=100&q=is:pr+user:alphagov+state:open+author:app/dependabot-preview+review:required")
+    stub_request(:get, "https://api.github.com/search/issues?per_page=100&q=is:pr+user:alphagov+state:open+author:app/dependabot+author:app/dependabot-preview+review:required")
       .to_return(body: File.read("spec/fixtures/pull_requests.json"), headers: { "Content-Type" => "application/json" })
-    stub_request(:get, "https://api.github.com/search/issues?per_page=100&q=is:pr+user:alphagov+state:open+author:app/dependabot-preview+review:changes_requested")
+    stub_request(:get, "https://api.github.com/search/issues?per_page=100&q=is:pr+user:alphagov+state:open+author:app/dependabot+author:app/dependabot-preview+review:changes_requested")
       .to_return(body: '{ "total_count": 0, "incomplete_results": false, "items": [] }', headers: { "Content-Type" => "application/json" })
 
     stub_request(:get, "https://docs.publishing.service.gov.uk/apps.json")

--- a/spec/gateways/pull_request_count_spec.rb
+++ b/spec/gateways/pull_request_count_spec.rb
@@ -1,7 +1,7 @@
 describe Gateways::PullRequestCount do
   context "when getting all PRs for dependabot" do
     before do
-      stub_request(:get, "https://api.github.com/search/issues?q=is:pr%20user:alphagov%20author:app/dependabot-preview")
+      stub_request(:get, "https://api.github.com/search/issues?q=is:pr%20user:alphagov%20author:app/dependabot%20author:app/dependabot-preview")
         .to_return(body: File.open("spec/fixtures/pull_requests.json"), headers: { "Content-Type" => "application/json" })
     end
     it "returns the total count" do

--- a/spec/gateways/pull_request_spec.rb
+++ b/spec/gateways/pull_request_spec.rb
@@ -1,7 +1,7 @@
 describe Gateways::PullRequest do
-  REVIEW_REQUIRED_URL = "https://api.github.com/search/issues?per_page=100&q=is:pr+user:alphagov+state:open+author:app/dependabot-preview+review:required".freeze
-  APPROVED_URL = "https://api.github.com/search/issues?per_page=100&q=is:pr+user:alphagov+state:open+author:app/dependabot-preview+review:approved".freeze
-  CHANGES_REQUESTED_URL = "https://api.github.com/search/issues?per_page=100&q=is:pr+user:alphagov+state:open+author:app/dependabot-preview+review:changes_requested".freeze
+  REVIEW_REQUIRED_URL = "https://api.github.com/search/issues?per_page=100&q=is:pr+user:alphagov+state:open+author:app/dependabot+author:app/dependabot-preview+review:required".freeze
+  APPROVED_URL = "https://api.github.com/search/issues?per_page=100&q=is:pr+user:alphagov+state:open+author:app/dependabot+author:app/dependabot-preview+review:approved".freeze
+  CHANGES_REQUESTED_URL = "https://api.github.com/search/issues?per_page=100&q=is:pr+user:alphagov+state:open+author:app/dependabot+author:app/dependabot-preview+review:changes_requested".freeze
   NO_PULL_REQUESTS_BODY = '{ "total_count": 0, "incomplete_results": false, "items": [] }'.freeze
 
   around do |example|


### PR DESCRIPTION
The automatic GitHub security vulnerability feature opens PRs under the name of `dependabot` rather than `dependabot-preview`.