### PR TITLE
Get all PRs with label "dependencies" on a repo

### DIFF
--- a/lib/presenters/slack/full_message.rb
+++ b/lib/presenters/slack/full_message.rb
@@ -17,7 +17,7 @@ module Presenters
       end
 
       def url(application_name)
-        "https://github.com/alphagov/#{application_name}/pulls/app/dependabot-preview"
+        "https://github.com/alphagov/#{application_name}/pulls?is:pr+is:open+label:dependencies"
       end
 
       def url_for_team(applications_by_team)

--- a/lib/use_cases/group/applications_by_team.rb
+++ b/lib/use_cases/group/applications_by_team.rb
@@ -36,7 +36,7 @@ module UseCases
         pull_requests_by_application.map do |application_name, pull_request_for_app|
           {
             application_name: application_name,
-            application_url: "https://github.com/alphagov/#{application_name}/pulls/app/dependabot-preview",
+            application_url: "https://github.com/alphagov/#{application_name}/pulls?is:pr+is:open+label:dependencies",
             pull_request_count: pull_request_for_app.count,
           }
         end

--- a/spec/acceptance/dependapanda_spec.rb
+++ b/spec/acceptance/dependapanda_spec.rb
@@ -50,11 +50,11 @@ describe Dependapanda do
   context "Full Message" do
     it "sends all the pull requests in the message" do
       modelling_services_payload = {
-        "payload" => '{"channel":"modelling-services","username":"Dependapanda","icon_emoji":":panda_face:","text":"<https://govuk-dependencies.herokuapp.com/team/modelling-services|modelling-services> have 2 Dependabot PRs open on the following apps:\n\n<https://github.com/alphagov/publisher/pulls/app/dependabot-preview|publisher> (2)"}',
+        "payload" => '{"channel":"modelling-services","username":"Dependapanda","icon_emoji":":panda_face:","text":"<https://govuk-dependencies.herokuapp.com/team/modelling-services|modelling-services> have 2 Dependabot PRs open on the following apps:\n\n<https://github.com/alphagov/publisher/pulls?is:pr+is:open+label:dependencies|publisher> (2)"}',
       }
 
       start_pages_payload = {
-        "payload" => '{"channel":"start-pages","username":"Dependapanda","icon_emoji":":panda_face:","text":"<https://govuk-dependencies.herokuapp.com/team/start-pages|start-pages> have 1 Dependabot PRs open on the following apps:\n\n<https://github.com/alphagov/frontend/pulls/app/dependabot-preview|frontend> (1)"}',
+        "payload" => '{"channel":"start-pages","username":"Dependapanda","icon_emoji":":panda_face:","text":"<https://govuk-dependencies.herokuapp.com/team/start-pages|start-pages> have 1 Dependabot PRs open on the following apps:\n\n<https://github.com/alphagov/frontend/pulls?is:pr+is:open+label:dependencies|frontend> (1)"}',
       }
 
       described_class.new.send_full_message

--- a/spec/presenters/slack/full_message_spec.rb
+++ b/spec/presenters/slack/full_message_spec.rb
@@ -6,7 +6,7 @@ describe Presenters::Slack::FullMessage do
         applications: [
           {
             application_name: "content-tagger",
-            application_url: "https://github.com/alphagov/content-tagger/app/dependabot-preview",
+            application_url: "https://github.com/alphagov/content-tagger?is:pr+is:open+label:dependencies",
             pull_request_count: 1,
           },
         ],
@@ -16,7 +16,7 @@ describe Presenters::Slack::FullMessage do
 
       expect(result).to eq('<https://govuk-dependencies.herokuapp.com/team/email|email> have 1 Dependabot PRs open on the following apps:
 
-<https://github.com/alphagov/content-tagger/pulls/app/dependabot-preview|content-tagger> (1)')
+<https://github.com/alphagov/content-tagger/pulls?is:pr+is:open+label:dependencies|content-tagger> (1)')
     end
   end
 
@@ -27,11 +27,11 @@ describe Presenters::Slack::FullMessage do
         applications: [
           {
             application_name: "collections-publisher",
-            application_url: "https://github.com/alphagov/content-publisher/app/dependabot-preview",
+            application_url: "https://github.com/alphagov/content-publisher?is:pr+is:open+label:dependencies",
             pull_request_count: 1,
           }, {
             application_name: "content-tagger",
-            application_url: "https://github.com/alphagov/content-tagger/app/dependabot-preview",
+            application_url: "https://github.com/alphagov/content-tagger?is:pr+is:open+label:dependencies",
             pull_request_count: 1,
           }
         ],
@@ -41,7 +41,7 @@ describe Presenters::Slack::FullMessage do
 
       expect(result).to eq('<https://govuk-dependencies.herokuapp.com/team/taxonomy|taxonomy> have 2 Dependabot PRs open on the following apps:
 
-<https://github.com/alphagov/collections-publisher/pulls/app/dependabot-preview|collections-publisher> (1) <https://github.com/alphagov/content-tagger/pulls/app/dependabot-preview|content-tagger> (1)')
+<https://github.com/alphagov/collections-publisher/pulls?is:pr+is:open+label:dependencies|collections-publisher> (1) <https://github.com/alphagov/content-tagger/pulls?is:pr+is:open+label:dependencies|content-tagger> (1)')
     end
 
     it "groups by application" do
@@ -50,11 +50,11 @@ describe Presenters::Slack::FullMessage do
         applications: [
           {
             application_name: "collections-publisher",
-            application_url: "https://github.com/alphagov/content-publisher/app/dependabot-preview",
+            application_url: "https://github.com/alphagov/content-publisher?is:pr+is:open+label:dependencies",
             pull_request_count: 1,
           }, {
             application_name: "content-tagger",
-            application_url: "https://github.com/alphagov/content-tagger/app/dependabot-preview",
+            application_url: "https://github.com/alphagov/content-tagger?is:pr+is:open+label:dependencies",
             pull_request_count: 2,
           }
         ],
@@ -64,7 +64,7 @@ describe Presenters::Slack::FullMessage do
 
       expect(result).to eq('<https://govuk-dependencies.herokuapp.com/team/taxonomy|taxonomy> have 3 Dependabot PRs open on the following apps:
 
-<https://github.com/alphagov/collections-publisher/pulls/app/dependabot-preview|collections-publisher> (1) <https://github.com/alphagov/content-tagger/pulls/app/dependabot-preview|content-tagger> (2)')
+<https://github.com/alphagov/collections-publisher/pulls?is:pr+is:open+label:dependencies|collections-publisher> (1) <https://github.com/alphagov/content-tagger/pulls?is:pr+is:open+label:dependencies|content-tagger> (2)')
     end
   end
 end

--- a/spec/presenters/slack/simple_message_spec.rb
+++ b/spec/presenters/slack/simple_message_spec.rb
@@ -6,7 +6,7 @@ describe Presenters::Slack::SimpleMessage do
         applications: [
           {
             application_name: "content-tagger",
-            application_url: "https://github.com/alphagov/content-tagger/app/dependabot-preview",
+            application_url: "https://github.com/alphagov/content-tagger?is:pr+is:open+label:dependencies",
             pull_request_count: 1,
           },
         ],

--- a/spec/use_cases/group/applications_by_team_spec.rb
+++ b/spec/use_cases/group/applications_by_team_spec.rb
@@ -30,7 +30,7 @@ describe UseCases::Group::ApplicationsByTeam do
             {
               application_name: "some-application",
               application_url:
-              "https://github.com/alphagov/some-application/pulls/app/dependabot-preview",
+              "https://github.com/alphagov/some-application/pulls?is:pr+is:open+label:dependencies",
               pull_request_count: 1,
             },
           ],
@@ -76,7 +76,7 @@ describe UseCases::Group::ApplicationsByTeam do
             {
               application_name: "collections",
               application_url:
-              "https://github.com/alphagov/collections/pulls/app/dependabot-preview",
+              "https://github.com/alphagov/collections/pulls?is:pr+is:open+label:dependencies",
               pull_request_count: 1,
             },
           ],
@@ -87,7 +87,7 @@ describe UseCases::Group::ApplicationsByTeam do
             {
               application_name: "collections-publisher",
               application_url:
-              "https://github.com/alphagov/collections-publisher/pulls/app/dependabot-preview",
+              "https://github.com/alphagov/collections-publisher/pulls?is:pr+is:open+label:dependencies",
               pull_request_count: 1,
             },
           ],
@@ -129,7 +129,7 @@ describe UseCases::Group::ApplicationsByTeam do
             {
               application_name: "collections",
               application_url:
-              "https://github.com/alphagov/collections/pulls/app/dependabot-preview",
+              "https://github.com/alphagov/collections/pulls?is:pr+is:open+label:dependencies",
               pull_request_count: 2,
             },
           ],


### PR DESCRIPTION
- Since GitHub acquired Dependabot, its username has been alternating
  between `app/dependabot` and `app/dependabot-preview`. This has the
  annoying side effect that both usernames can raise PRs with the label
  "dependencies", and the count of PRs (which searches for both
  usernames) and the `application_url` link that lists the PRs sometimes
  don't match up. For example, govuk_app_config has a correct count of 3
  "dependencies" label PRs, raised by app/dependabot, but the
  `application_url` was hardcoding `app/dependabot-preview` in the
  filters.
- Get around this by using the more verbose but _correct_ `is:pr is:open
  label:dependencies` search in the URL for the pull request page.