### PR TITLE
Rename GITHUB_TOKEN to DEPENDENCIES_GITHUB_TOKEN

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,14 +37,14 @@ Running this will start your application at [localhost:9292](localhost:9292)
 
 ### Environment variables
 
-- `GITHUB_TOKEN` - OAuth token generated on GitHub which does not require any special permissions
+- `DEPENDENCIES_GITHUB_TOKEN` - OAuth token generated on GitHub which does not require any special permissions
   - Used to interact with the GitHub API, although not required it will help avoid limiting
 - `SLACK_WEBHOOK_URL` - The webhook URL for sending Slack messages to
 - `DEPENDAPANDA_SECRET` - Secret token for manually requesting Slack messages
 
 ### Rate limiting
 
-If you find yourself being rate limited by GitHub - you can define the `GITHUB_TOKEN` environment variable.
+If you find yourself being rate limited by GitHub - you can define the `DEPENDENCIES_GITHUB_TOKEN` environment variable.
 This needs to be a token generated from GitHub, however as the repositories are all public it needs no special
 permissions.
 

--- a/lib/gateways/pull_request.rb
+++ b/lib/gateways/pull_request.rb
@@ -3,7 +3,7 @@ require "octokit"
 module Gateways
   class PullRequest
     def initialize
-      @octokit = Octokit::Client.new(access_token: ENV["GITHUB_TOKEN"], auto_paginate: true)
+      @octokit = Octokit::Client.new(access_token: ENV["DEPENDENCIES_GITHUB_TOKEN"], auto_paginate: true)
     end
 
     def execute

--- a/lib/gateways/pull_request_count.rb
+++ b/lib/gateways/pull_request_count.rb
@@ -1,7 +1,7 @@
 module Gateways
   class PullRequestCount
     def initialize
-      @octokit = Octokit::Client.new(access_token: ENV["GITHUB_TOKEN"])
+      @octokit = Octokit::Client.new(access_token: ENV["DEPENDENCIES_GITHUB_TOKEN"])
     end
 
     def execute

--- a/lib/gateways/repositories.rb
+++ b/lib/gateways/repositories.rb
@@ -4,7 +4,7 @@ module Gateways
   class Repositories
     def initialize
       @octokit = Octokit::Client.new(
-        access_token: ENV.fetch("GITHUB_TOKEN"),
+        access_token: ENV.fetch("DEPENDENCIES_GITHUB_TOKEN"),
         auto_paginate: true,
       )
     end

--- a/spec/acceptance/app_spec.rb
+++ b/spec/acceptance/app_spec.rb
@@ -9,7 +9,7 @@ describe GovukDependencies do
   def app() described_class end
 
   around do |example|
-    ClimateControl.modify GITHUB_TOKEN: "some_token" do
+    ClimateControl.modify DEPENDENCIES_GITHUB_TOKEN: "some_token" do
       VCR.use_cassette("repositories") do
         example.run
       end

--- a/spec/acceptance/dependapanda_spec.rb
+++ b/spec/acceptance/dependapanda_spec.rb
@@ -2,7 +2,7 @@ require_relative "../../dependapanda"
 
 describe Dependapanda do
   around do |example|
-    ClimateControl.modify GITHUB_TOKEN: "some_token" do
+    ClimateControl.modify DEPENDENCIES_GITHUB_TOKEN: "some_token" do
       VCR.use_cassette("repositories") do
         Timecop.freeze("2019-09-27") do
           example.run

--- a/spec/gateways/pull_request_spec.rb
+++ b/spec/gateways/pull_request_spec.rb
@@ -5,7 +5,7 @@ describe Gateways::PullRequest do
   NO_PULL_REQUESTS_BODY = '{ "total_count": 0, "incomplete_results": false, "items": [] }'.freeze
 
   around do |example|
-    ClimateControl.modify GITHUB_TOKEN: "some_token" do
+    ClimateControl.modify DEPENDENCIES_GITHUB_TOKEN: "some_token" do
       VCR.use_cassette("repositories") do
         example.run
       end

--- a/spec/gateways/repositories_spec.rb
+++ b/spec/gateways/repositories_spec.rb
@@ -1,6 +1,6 @@
 describe Gateways::Repositories do
   around do |example|
-    ClimateControl.modify GITHUB_TOKEN: "some_token" do
+    ClimateControl.modify DEPENDENCIES_GITHUB_TOKEN: "some_token" do
       VCR.use_cassette("repositories") do
         example.run
       end


### PR DESCRIPTION
The `GITHUB_TOKEN` environment variable is also used for other projects.
See https://github.com/alphagov/govuk-aws/blob/master/tools/deploy.rb#L18

Changing it to `DEPENDENCIES_GITHUB_TOKEN` allows us to export it
without the risk of conflicts.