### PR TITLE
Highlight CD-enabled apps in Dependabot messages

### DIFF
--- a/.rspec
+++ b/.rspec
@@ -1,0 +1,1 @@
+--require spec_helper

--- a/lib/domain/team.rb
+++ b/lib/domain/team.rb
@@ -1,10 +1,11 @@
 module Domain
   class Team
-    attr_reader :team_name, :applications
+    attr_reader :team_name, :applications, :continuously_deployed_apps
 
-    def initialize(team_name:, applications:)
+    def initialize(team_name:, applications:, continuously_deployed_apps:)
       @team_name = team_name
       @applications = applications
+      @continuously_deployed_apps = continuously_deployed_apps
     end
   end
 end

--- a/lib/gateways/team.rb
+++ b/lib/gateways/team.rb
@@ -13,6 +13,7 @@ module Gateways
         Domain::Team.new(
           team_name: (name || default_team_name).tr("#", ""),
           applications: apps.map { |app| app["app_name"] },
+          continuously_deployed_apps: apps.filter { |app| app["continuously_deployed"] }.map { |app| app["app_name"] },
         )
       end
     end

--- a/lib/presenters/slack/simple_message.rb
+++ b/lib/presenters/slack/simple_message.rb
@@ -1,7 +1,9 @@
 module Presenters
   module Slack
     class SimpleMessage
-      def execute(applications_by_team:)
+      # rubocop:disable Lint/UnusedMethodArgument
+      def execute(applications_by_team:, continuously_deployed_apps:)
+        # rubocop:enable Lint/UnusedMethodArgument
         "You have #{pull_requests_count(applications_by_team)} open Dependabot PR(s) - #{url(applications_by_team)}"
       end
 

--- a/lib/use_cases/slack/send_messages.rb
+++ b/lib/use_cases/slack/send_messages.rb
@@ -38,9 +38,13 @@ module UseCases
 
       def send_messages(applications_by_teams)
         applications_by_teams.each do |applications_by_team|
+          team = team_usecase.execute.find { |app| app[:team_name] == applications_by_team.fetch(:team_name) }
           slack_gateway.execute(
             channel: applications_by_team.fetch(:team_name),
-            message: message_presenter.execute(applications_by_team: applications_by_team),
+            message: message_presenter.execute(
+              applications_by_team: applications_by_team,
+              continuously_deployed_apps: team.nil? ? nil : team[:continuously_deployed_apps],
+            ),
           )
         end
       end

--- a/lib/use_cases/teams/fetch.rb
+++ b/lib/use_cases/teams/fetch.rb
@@ -12,6 +12,7 @@ module UseCases
           {
             team_name: team.team_name,
             applications: team.applications,
+            continuously_deployed_apps: team.continuously_deployed_apps,
           }
         end
       end

--- a/spec/fixtures/application_with_no_team.json
+++ b/spec/fixtures/application_with_no_team.json
@@ -2,6 +2,7 @@
   "app_name":"asset-manager",
   "team": null,
   "puppet_name":"asset_manager",
+  "continuously_deployed": true,
   "links":{
     "self":"https://docs.publishing.service.gov.uk/apps/asset-manager.json",
     "html_url":"https://docs.publishing.service.gov.uk/apps/asset-manager.html",

--- a/spec/fixtures/multiple_teams_with_multiple_applications.json
+++ b/spec/fixtures/multiple_teams_with_multiple_applications.json
@@ -1,5 +1,42 @@
 [
-  {"app_name":"publisher","product_manager":"@samdub","team":"#modelling-services","dependencies_team":"#govuk-platform-health","puppet_name":"publisher","links":{"self":"https://docs.publishing.service.gov.uk/apps/publisher.json","html_url":"https://docs.publishing.service.gov.uk/apps/publisher.html","repo_url":"https://github.com/alphagov/publisher","sentry_url":"https://sentry.io/govuk/app-publisher"}},
-  {"app_name":"frontend","product_manager":"@humin_miah","team":"#start-pages","dependencies_team":"#govuk-platform-health","puppet_name":"frontend","links":{"self":"https://docs.publishing.service.gov.uk/apps/frontend.json","html_url":"https://docs.publishing.service.gov.uk/apps/frontend.html","repo_url":"https://github.com/alphagov/frontend","sentry_url":"https://sentry.io/govuk/app-frontend"}},
-  {"app_name":"government-frontend","product_manager":"@humin_miah","team":"#start-pages","dependencies_team":"#govuk-searchandnav","puppet_name":"government_frontend","links":{"self":"https://docs.publishing.service.gov.uk/apps/government-frontend.json","html_url":"https://docs.publishing.service.gov.uk/apps/government-frontend.html","repo_url":"https://github.com/alphagov/government-frontend","sentry_url":"https://sentry.io/govuk/app-government-frontend"}}
+  {
+    "app_name": "publisher",
+    "product_manager": "@samdub",
+    "team": "#modelling-services",
+    "dependencies_team": "#govuk-platform-health",
+    "puppet_name": "publisher",
+    "links": {
+      "self": "https://docs.publishing.service.gov.uk/apps/publisher.json",
+      "html_url": "https://docs.publishing.service.gov.uk/apps/publisher.html",
+      "repo_url": "https://github.com/alphagov/publisher",
+      "sentry_url": "https://sentry.io/govuk/app-publisher"
+    }
+  },
+  {
+    "app_name": "frontend",
+    "product_manager": "@humin_miah",
+    "team": "#start-pages",
+    "dependencies_team": "#govuk-platform-health",
+    "puppet_name": "frontend",
+    "links": {
+      "self": "https://docs.publishing.service.gov.uk/apps/frontend.json",
+      "html_url": "https://docs.publishing.service.gov.uk/apps/frontend.html",
+      "repo_url": "https://github.com/alphagov/frontend",
+      "sentry_url": "https://sentry.io/govuk/app-frontend"
+    }
+  },
+  {
+    "app_name": "government-frontend",
+    "product_manager": "@humin_miah",
+    "team": "#start-pages",
+    "dependencies_team": "#govuk-searchandnav",
+    "continuously_deployed": true,
+    "puppet_name": "government_frontend",
+    "links": {
+      "self": "https://docs.publishing.service.gov.uk/apps/government-frontend.json",
+      "html_url": "https://docs.publishing.service.gov.uk/apps/government-frontend.html",
+      "repo_url": "https://github.com/alphagov/government-frontend",
+      "sentry_url": "https://sentry.io/govuk/app-government-frontend"
+    }
+  }
 ]

--- a/spec/fixtures/team_with_one_application.json
+++ b/spec/fixtures/team_with_one_application.json
@@ -4,6 +4,7 @@
   "team":"#asset-management",
   "dependencies_team":"#govuk-pub-workflow",
   "puppet_name":"asset_manager",
+  "continuously_deployed": true,
   "links":{
     "self":"https://docs.publishing.service.gov.uk/apps/asset-manager.json",
     "html_url":"https://docs.publishing.service.gov.uk/apps/asset-manager.html",

--- a/spec/fixtures/team_with_two_applications.json
+++ b/spec/fixtures/team_with_two_applications.json
@@ -5,6 +5,7 @@
     "team":"#asset-management",
     "dependencies_team":"#govuk-platform-health",
     "puppet_name":"asset_manager",
+    "continuously_deployed": true,
     "links":{
       "self":"https://docs.publishing.service.gov.uk/apps/asset-manager.json",
       "html_url":"https://docs.publishing.service.gov.uk/apps/asset-manager.html",

--- a/spec/gateways/team_spec.rb
+++ b/spec/gateways/team_spec.rb
@@ -25,6 +25,7 @@ describe Gateways::Team do
       expect(result.count).to eq(1)
       expect(result.first.team_name).to eq("govuk-developers")
       expect(result.first.applications).to eq(%w[asset-manager])
+      expect(result.first.continuously_deployed_apps).to eq(%w[asset-manager])
     end
   end
 
@@ -43,6 +44,7 @@ describe Gateways::Team do
         expect(result.count).to eq(1)
         expect(result.first.team_name).to eq("govuk-pub-workflow")
         expect(result.first.applications).to eq(%w[asset-manager])
+        expect(result.first.continuously_deployed_apps).to eq(%w[asset-manager])
       end
     end
 
@@ -60,6 +62,7 @@ describe Gateways::Team do
         expect(result.count).to eq(1)
         expect(result.first.team_name).to eq("govuk-platform-health")
         expect(result.first.applications).to eq(%w[asset-manager asset-uploader])
+        expect(result.first.continuously_deployed_apps).to eq(%w[asset-manager])
       end
     end
   end
@@ -79,9 +82,11 @@ describe Gateways::Team do
       expect(result.count).to eq(2)
       expect(result.first.team_name).to eq("govuk-platform-health")
       expect(result.first.applications).to eq(%w[publisher frontend])
+      expect(result.first.continuously_deployed_apps).to eq([])
 
       expect(result.last.team_name).to eq("govuk-searchandnav")
       expect(result.last.applications).to eq(%w[government-frontend])
+      expect(result.last.continuously_deployed_apps).to eq(%w[government-frontend])
     end
   end
 end

--- a/spec/presenters/slack/full_message_spec.rb
+++ b/spec/presenters/slack/full_message_spec.rb
@@ -68,5 +68,37 @@ describe Presenters::Slack::FullMessage do
 
 <https://github.com/alphagov/collections-publisher/pulls?q=is:pr+is:open+label:dependencies|collections-publisher> (1) <https://github.com/alphagov/content-tagger/pulls?q=is:pr+is:open+label:dependencies|content-tagger> (2)')
     end
+
+    it "highlights the continuously deployed apps" do
+      applications_by_team = {
+        team_name: "taxonomy",
+        applications: [
+          {
+            application_name: "collections-publisher",
+            application_url: "https://github.com/alphagov/content-publisher?q=is:pr+is:open+label:dependencies",
+            pull_request_count: 1,
+          },
+          {
+            application_name: "content-tagger",
+            application_url: "https://github.com/alphagov/content-tagger?q=is:pr+is:open+label:dependencies",
+            pull_request_count: 2,
+          },
+        ],
+      }
+      continuously_deployed_apps = %w[collections-publisher]
+
+      result = described_class.new.execute(
+        applications_by_team: applications_by_team,
+        continuously_deployed_apps: continuously_deployed_apps,
+      )
+
+      expect(result).to eq('<https://govuk-dependencies.herokuapp.com/team/taxonomy|taxonomy> have 1 Dependabot PRs open on the following Continuously Deployed apps:
+
+<https://github.com/alphagov/collections-publisher/pulls?q=is:pr+is:open+label:dependencies|collections-publisher> (1)
+
+And 2 Dependabot PRs open on other apps:
+
+<https://github.com/alphagov/content-tagger/pulls?q=is:pr+is:open+label:dependencies|content-tagger> (2)')
+    end
   end
 end

--- a/spec/presenters/slack/simple_message_spec.rb
+++ b/spec/presenters/slack/simple_message_spec.rb
@@ -11,7 +11,7 @@ describe Presenters::Slack::SimpleMessage do
           },
         ],
       }
-      result = described_class.new.execute(applications_by_team: applications_by_team)
+      result = described_class.new.execute(applications_by_team: applications_by_team, continuously_deployed_apps: [])
 
       expect(result).to eq("You have 1 open Dependabot PR(s) - https://govuk-dependencies.herokuapp.com/team/email")
     end


### PR DESCRIPTION
Depends on https://github.com/alphagov/govuk-developer-docs/pull/2949 and https://github.com/alphagov/govuk-developer-docs/pull/2950.

This change draws attention to PRs which can be merged & deployed with one click, thanks to the Continuous Deployment process. This should mean developers are more open to merging Dependabot PRs.

## Preview

### Before

> [taxonomy](https://govuk-dependencies.herokuapp.com/team/taxonomy) have 3 Dependabot PRs open on the following apps:
>
> [collections-publisher](https://github.com/alphagov/collections-publisher/pulls?q=is:pr+is:open+label:dependencies) (1) [content-tagger](https://github.com/alphagov/content-tagger/pulls?q=is:pr+is:open+label:dependencies) (2)

### After

> [taxonomy](https://govuk-dependencies.herokuapp.com/team/taxonomy) have 1 Dependabot PRs open on the following Continuously Deployed apps:
>
> [collections-publisher](https://github.com/alphagov/collections-publisher/pulls?q=is:pr+is:open+label:dependencies) (1)
>
> And 2 Dependabot PRs open on other apps:
>
> [content-tagger](https://github.com/alphagov/content-tagger/pulls?q=is:pr+is:open+label:dependencies) (2)
