### PR TITLE
Improve Continuously-Deployed apps logic

### DIFF
--- a/lib/presenters/slack/full_message.rb
+++ b/lib/presenters/slack/full_message.rb
@@ -3,8 +3,8 @@ module Presenters
     class FullMessage
       def execute(applications_by_team:, continuously_deployed_apps: [])
         applications = applications_by_team.fetch(:applications)
-        if continuously_deployed_apps.any?
-          cd_apps = applications.filter { |app| continuously_deployed_apps.include?(app.fetch(:application_name)) }
+        cd_apps = applications.filter { |app| continuously_deployed_apps.include?(app.fetch(:application_name)) }
+        if pull_requests_count(cd_apps).positive?
           "#{url_for_team(applications_by_team)} have #{pull_requests_count(cd_apps)} Dependabot PRs open on the following Continuously Deployed apps:
 
 #{body(cd_apps).join(' ')}

--- a/lib/use_cases/distribute/overflow_to_developers_channel.rb
+++ b/lib/use_cases/distribute/overflow_to_developers_channel.rb
@@ -6,14 +6,24 @@ module UseCases
         @overflow_at = overflow_at
 
         redistribution = []
+        continuously_deployed_apps = []
 
         application_prs_by_team.each do |application_prs_for_team|
           redistribution.concat(redistribute(application_prs_for_team[:applications]))
+          if application_prs_for_team[:continuously_deployed_apps]
+            continuously_deployed_apps.concat(application_prs_for_team[:continuously_deployed_apps])
+          end
         end
 
         if redistribution.any?
           ensure_govuk_developers_exists
           govuk_developers_application_prs[:applications].concat(redistribution)
+          redistribution.each do |app|
+            if continuously_deployed_apps.include?(app[:application_name])
+              govuk_developers_application_prs[:continuously_deployed_apps] << app[:application_name]
+            end
+          end
+          # govuk_developers_application_prs[:continuously_deployed_apps].concat("foo")
         end
 
         application_prs_by_team
@@ -25,7 +35,7 @@ module UseCases
 
       def ensure_govuk_developers_exists
         unless govuk_developers_application_prs
-          application_prs_by_team << { team_name: "govuk-developers", applications: [] }
+          application_prs_by_team << { team_name: "govuk-developers", applications: [], continuously_deployed_apps: [] }
         end
       end
 

--- a/spec/use_cases/distribute/overflow_to_developers_channel_spec.rb
+++ b/spec/use_cases/distribute/overflow_to_developers_channel_spec.rb
@@ -116,4 +116,41 @@ describe UseCases::Distribute::OverflowToDevelopersChannel do
       expect(overflow_with_dev_team).to have_application_count_for_team(6, "govuk-developers")
     end
   end
+
+  context "with continuously_deployed_apps" do
+    let(:prs_by_team) do
+      [
+        {
+          team_name: "govuk-platform-health",
+          continuously_deployed_apps: %w[whitehall signon support content-publisher],
+          applications:
+            [
+              { application_name: "whitehall", pull_request_count: 5 },
+              { application_name: "signon", pull_request_count: 4 },
+              { application_name: "ckanext-datagovuk", pull_request_count: 3 },
+              { application_name: "collections-publisher", pull_request_count: 2 },
+              { application_name: "content-data-admin", pull_request_count: 1 },
+              { application_name: "content-publisher", pull_request_count: 1 },
+              { application_name: "support", pull_request_count: 1 },
+            ],
+        },
+        {
+          team_name: "govuk-top-team",
+          applications:
+            [
+              { application_name: "not-another-whitehall", pull_request_count: 1 },
+            ],
+        },
+      ]
+    end
+
+    let(:overflow_with_dev_team) do
+      distribute(prs_by_team, 5)
+    end
+
+    it "should retain the continuously_deployed_apps information" do
+      govuk_developers = overflow_with_dev_team.find { |h| h[:team_name] == "govuk-developers" }
+      expect(govuk_developers[:continuously_deployed_apps]).to eq(%w[content-publisher support])
+    end
+  end
 end


### PR DESCRIPTION
The first commit improves the conditional logic so that we don't see a "0 Dependabot PRs" message when there are CD repos for the current team, but no CD PRs:

![](https://user-images.githubusercontent.com/5111927/107197652-10346680-69ec-11eb-926d-64b8f02f74a5.png)

The second commit fixes an oversight in #104 whereby `#govuk-developers` Dependabot messages are subject to an 'overflow' mechanism which meant the `continuously_deployed_apps` information was being filtered out.