### PR TITLE
Add a cache and warm it up

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,6 +2,8 @@ source "https://rubygems.org"
 
 ruby File.read(".ruby-version").chomp
 
+gem "dalli"
+gem "memcachier"
 gem "octokit", "~> 4.3"
 gem "rake", "~> 12.3.0"
 gem "sinatra"

--- a/Gemfile
+++ b/Gemfile
@@ -2,6 +2,7 @@ source "https://rubygems.org"
 
 ruby File.read(".ruby-version").chomp
 
+gem "activesupport"
 gem "dalli"
 gem "memcachier"
 gem "octokit", "~> 4.3"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -119,6 +119,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  activesupport
   climate_control (~> 0.2)
   dalli
   memcachier

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -15,6 +15,7 @@ GEM
     concurrent-ruby (1.1.9)
     crack (0.4.3)
       safe_yaml (~> 1.0.0)
+    dalli (3.0.4)
     diff-lcs (1.4.4)
     faraday (0.17.4)
       multipart-post (>= 1.2, < 3)
@@ -22,6 +23,7 @@ GEM
     i18n (1.8.10)
       concurrent-ruby (~> 1.0)
     kgio (2.11.2)
+    memcachier (0.0.2)
     method_source (0.9.0)
     minitest (5.14.4)
     multipart-post (2.1.1)
@@ -118,6 +120,8 @@ PLATFORMS
 
 DEPENDENCIES
   climate_control (~> 0.2)
+  dalli
+  memcachier
   octokit (~> 4.3)
   pry (~> 0.11.3)
   rack-test (~> 1.1.0)

--- a/Rakefile
+++ b/Rakefile
@@ -62,7 +62,7 @@ end
 
 desc "Flush all data from the memcache server on production. Consider manually refilling the cache with fetch tasks above."
 task :flush_cache do
-  GovukDependencies.cache.flush_all
+  GovukDependencies.cache.clear
 end
 
 desc "Recreate the vcr cassettes. For example `rake record_cassette[org:alphagov topic:govuk]`"

--- a/Rakefile
+++ b/Rakefile
@@ -1,4 +1,6 @@
 require_relative "dependapanda"
+require_relative "lib/gateways/repositories"
+require_relative "lib/gateways/pull_request"
 require "vcr"
 require "net/http"
 
@@ -19,6 +21,48 @@ end
 desc "Send complete dependency audit"
 task :dependapanda_loud do
   Dependapanda.new.send_full_message
+end
+
+desc "Fetch alphagov repos tagged to govuk"
+task :fetch_repos do
+  Gateways::Repositories.new.raw_govuk_repos
+end
+
+desc "Fetch approved dependabot PR's"
+task :fetch_approved_pull_requests do
+  Gateways::PullRequest.new.approved_pull_requests
+end
+
+desc "Fetch changes requested dependabot PR's"
+task :fetch_changes_requested_pull_requests do
+  Gateways::PullRequest.new.changes_requested_pull_requests
+end
+
+desc "Fetch review required dependabot PR's"
+task :fetch_review_required_pull_requests do
+  Gateways::PullRequest.new.review_required_pull_requests
+end
+
+desc "Fetch all of the data we need from github in a slow way, and write to the cache"
+task :warm_the_cache do
+  Rake::Task["fetch_repos"].invoke
+  puts "fetched repos"
+  sleep 10
+  Rake::Task["fetch_approved_pull_requests"].invoke
+  puts "fetched approved PRs"
+  sleep 10
+  Rake::Task["fetch_changes_requested_pull_requests"].invoke
+  puts "fetched changes requested PRs"
+  sleep 15
+  Rake::Task["fetch_review_required_pull_requests"].invoke
+  puts "fetched review required requested PRs"
+rescue Octokit::Forbidden
+  puts "We've been rate limited. Wait 15 seconds and then hit refresh on the app, or run this task again"
+end
+
+desc "Flush all data from the memcache server on production. Consider manually refilling the cache with fetch tasks above."
+task :flush_cache do
+  GovukDependencies.cache.flush_all
 end
 
 desc "Recreate the vcr cassettes. For example `rake record_cassette[org:alphagov topic:govuk]`"

--- a/app.json
+++ b/app.json
@@ -16,7 +16,7 @@
     }
   },
   "addons": [
-
+    "memcachier"
   ],
   "buildpacks": [
     {

--- a/app.rb
+++ b/app.rb
@@ -1,6 +1,8 @@
 require "sinatra"
 require "dalli"
 require_relative "lib/loader"
+require_relative "config/initializers/cache_store"
+require "active_support"
 
 class GovukDependencies < Sinatra::Base
   get "/" do
@@ -61,4 +63,4 @@ class GovukDependencies < Sinatra::Base
   end
 end
 
-GovukDependencies.set cache: Dalli::Client.new(ENV["MEMCACHIER_SERVERS"], { username: ENV["MEMCACHIER_USERNAME"], password: ENV["MEMCACHIER_PASSWORD"] })
+GovukDependencies.set cache: CacheStore.store

--- a/app.rb
+++ b/app.rb
@@ -1,4 +1,5 @@
 require "sinatra"
+require "dalli"
 require_relative "lib/loader"
 
 class GovukDependencies < Sinatra::Base
@@ -59,3 +60,5 @@ class GovukDependencies < Sinatra::Base
     "[ok]"
   end
 end
+
+GovukDependencies.set cache: Dalli::Client.new(ENV["MEMCACHIER_SERVERS"], { username: ENV["MEMCACHIER_USERNAME"], password: ENV["MEMCACHIER_PASSWORD"] })

--- a/config/initializers/cache_store.rb
+++ b/config/initializers/cache_store.rb
@@ -1,0 +1,41 @@
+require "active_support"
+require "dalli"
+
+module CacheStore
+  CACHE_EXPIRY = 43_200 # 12 hours
+
+  def self.memcached
+    @memcached ||=
+      Dalli::Client.new(
+        ENV["MEMCACHIER_SERVERS"], {
+          username: ENV["MEMCACHIER_USERNAME"],
+          password: ENV["MEMCACHIER_PASSWORD"],
+          expires_in: CACHE_EXPIRY,
+        }
+      )
+  end
+
+  def self.filestore
+    @filestore ||= ActiveSupport::Cache::FileStore.new(".cache")
+  end
+
+  def self.store
+    cache_store = ENV["RACK_ENV"] == "production" ? memcached : filestore
+    Store.new(cache_store)
+  end
+end
+
+class CacheStore::Store < SimpleDelegator
+  def initialize(cache)
+    super
+    @cache = cache
+  end
+
+  def clear
+    @cache.respond_to?(:flush_all) ? @cache.flush_all : @cache.clear
+  end
+
+  def write(key, value)
+    @cache.respond_to?(:set) ? @cache.set(key, value) : @cache.write(key, value)
+  end
+end

--- a/config/initializers/github_client.rb
+++ b/config/initializers/github_client.rb
@@ -1,0 +1,15 @@
+require "octokit"
+
+class GithubClient
+  def initialize
+    @access_token = ENV["GITHUB_TOKEN"]
+  end
+
+  def client(auto_paginate: true)
+    Octokit::Client.new(access_token: access_token, auto_paginate: auto_paginate)
+  end
+
+private
+
+  attr_reader :access_token
+end

--- a/lib/gateways/pull_request.rb
+++ b/lib/gateways/pull_request.rb
@@ -81,7 +81,7 @@ module Gateways
     end
 
     def govuk_repository_urls
-      @govuk_repository_urls ||= Gateways::Repositories.new.execute.map(&:url)
+      @govuk_repository_urls ||= Gateways::Repositories.new.govuk_repo_urls
     end
 
     def get_application_name(pull_request)

--- a/lib/gateways/pull_request.rb
+++ b/lib/gateways/pull_request.rb
@@ -1,9 +1,7 @@
-require "octokit"
-
 module Gateways
   class PullRequest
     def initialize
-      @octokit = Octokit::Client.new(access_token: ENV["GITHUB_TOKEN"], auto_paginate: true)
+      @client = GithubClient.new.client
     end
 
     def execute
@@ -13,17 +11,17 @@ module Gateways
   private
 
     def approved_pull_requests
-      approved_pull_requests = @octokit.search_issues("is:pr user:alphagov state:open author:app/dependabot author:app/dependabot-preview review:approved").items
+      approved_pull_requests = @client.search_issues("is:pr user:alphagov state:open author:app/dependabot author:app/dependabot-preview review:approved").items
       build_pull_requests(approved_pull_requests, "approved")
     end
 
     def review_required_pull_requests
-      review_required_pull_requests = @octokit.search_issues("is:pr user:alphagov state:open author:app/dependabot author:app/dependabot-preview review:required").items
+      review_required_pull_requests = @client.search_issues("is:pr user:alphagov state:open author:app/dependabot author:app/dependabot-preview review:required").items
       build_pull_requests(review_required_pull_requests, "review required")
     end
 
     def changes_requested_pull_requests
-      changes_requested_pull_requests = @octokit.search_issues("is:pr user:alphagov state:open author:app/dependabot author:app/dependabot-preview review:changes_requested").items
+      changes_requested_pull_requests = @client.search_issues("is:pr user:alphagov state:open author:app/dependabot author:app/dependabot-preview review:changes_requested").items
       build_pull_requests(changes_requested_pull_requests, "changes requested")
     end
 

--- a/lib/gateways/pull_request.rb
+++ b/lib/gateways/pull_request.rb
@@ -2,7 +2,6 @@ require_relative "../../app"
 
 module Gateways
   class PullRequest
-    CACHE_EXPIRY = 43_200 # 12 hours
     def initialize
       @client = GithubClient.new.client
     end
@@ -18,7 +17,7 @@ module Gateways
       query = "is:pr user:alphagov state:open author:app/dependabot author:app/dependabot-preview review:approved"
       @approved_pull_requests ||= GovukDependencies.cache.fetch("approved") do
         approved = @client.search_issues(query).items
-        GovukDependencies.cache.set("approved", approved, CACHE_EXPIRY)
+        GovukDependencies.cache.write("approved", approved)
         approved
       end
     end
@@ -26,7 +25,7 @@ module Gateways
     def review_required_pull_requests
       @review_required_pull_requests ||= GovukDependencies.cache.fetch("review_required") do
         review_required = fetch_review_required_pull_requests
-        GovukDependencies.cache.set("review_required", review_required, CACHE_EXPIRY)
+        GovukDependencies.cache.write("review_required", review_required)
         review_required
       end
     end
@@ -35,7 +34,7 @@ module Gateways
       query = "is:pr user:alphagov state:open author:app/dependabot author:app/dependabot-preview review:changes_requested"
       @changes_requested_pull_requests ||= GovukDependencies.cache.fetch("changes_requested") do
         changes_requested = @client.search_issues(query).items
-        GovukDependencies.cache.set("changes_requested", changes_requested, CACHE_EXPIRY)
+        GovukDependencies.cache.write("changes_requested", changes_requested)
         changes_requested
       end
     end

--- a/lib/gateways/pull_request.rb
+++ b/lib/gateways/pull_request.rb
@@ -9,9 +9,7 @@ module Gateways
 
     def execute
       a = build_pull_requests(approved_pull_requests, "approved")
-      sleep 10
       c = build_pull_requests(changes_requested_pull_requests, "changes requested")
-      sleep 10
       r = build_pull_requests(review_required_pull_requests, "review required")
       a + c + r
     end

--- a/lib/gateways/pull_request_count.rb
+++ b/lib/gateways/pull_request_count.rb
@@ -1,11 +1,11 @@
 module Gateways
   class PullRequestCount
     def initialize
-      @octokit = Octokit::Client.new(access_token: ENV["GITHUB_TOKEN"])
+      @client = GithubClient.new.client(auto_paginate: false)
     end
 
     def execute
-      @octokit.search_issues("is:pr user:alphagov author:app/dependabot author:app/dependabot-preview").total_count
+      @client.search_issues("is:pr user:alphagov author:app/dependabot author:app/dependabot-preview").total_count
     end
   end
 end

--- a/lib/gateways/repositories.rb
+++ b/lib/gateways/repositories.rb
@@ -3,14 +3,11 @@ require "octokit"
 module Gateways
   class Repositories
     def initialize
-      @octokit = Octokit::Client.new(
-        access_token: ENV.fetch("GITHUB_TOKEN"),
-        auto_paginate: true,
-      )
+      @client = GithubClient.new.client
     end
 
     def execute
-      @octokit.search_repos("org:alphagov topic:govuk").items.map do |repo|
+      @client.search_repos("org:alphagov topic:govuk").items.map do |repo|
         Domain::Repository.new(name: repo.name, url: repo.url)
       end
     end

--- a/lib/gateways/repositories.rb
+++ b/lib/gateways/repositories.rb
@@ -1,14 +1,27 @@
-require "octokit"
+require_relative "../../app"
 
 module Gateways
   class Repositories
+    CACHE_EXPIRY = 43_200 # 12 hours
     def initialize
       @client = GithubClient.new.client
     end
 
-    def execute
-      @client.search_repos("org:alphagov topic:govuk").items.map do |repo|
+    def govuk_repo_urls
+      parsed_govuk_repos.map(&:url)
+    end
+
+    def parsed_govuk_repos
+      @parsed_govuk_repos ||= raw_govuk_repos.map do |repo|
         Domain::Repository.new(name: repo.name, url: repo.url)
+      end
+    end
+
+    def raw_govuk_repos
+      @raw_govuk_repos ||= GovukDependencies.cache.fetch("govuk-repos") do
+        repos = @client.search_repos("org:alphagov topic:govuk").items
+        GovukDependencies.cache.set("govuk-repos", repos, CACHE_EXPIRY)
+        repos
       end
     end
   end

--- a/lib/gateways/repositories.rb
+++ b/lib/gateways/repositories.rb
@@ -2,7 +2,6 @@ require_relative "../../app"
 
 module Gateways
   class Repositories
-    CACHE_EXPIRY = 43_200 # 12 hours
     def initialize
       @client = GithubClient.new.client
     end
@@ -20,7 +19,7 @@ module Gateways
     def raw_govuk_repos
       @raw_govuk_repos ||= GovukDependencies.cache.fetch("govuk-repos") do
         repos = @client.search_repos("org:alphagov topic:govuk").items
-        GovukDependencies.cache.set("govuk-repos", repos, CACHE_EXPIRY)
+        GovukDependencies.cache.write("govuk-repos", repos)
         repos
       end
     end

--- a/lib/loader.rb
+++ b/lib/loader.rb
@@ -1,2 +1,3 @@
 Dir.glob("./lib/{domain,use_cases,gateways,presenters}/**/*.rb").sort.each { |file| require file }
 Dir.glob("./helpers/*.rb").sort.each { |file| require file }
+Dir.glob("./config/initializers/*.rb").sort.each { |file| require file }

--- a/spec/acceptance/app_spec.rb
+++ b/spec/acceptance/app_spec.rb
@@ -2,8 +2,6 @@ require "spec_helper"
 require "rack/test"
 require_relative "../../app"
 
-ENV["RACK_ENV"] = "test"
-
 describe GovukDependencies do
   include StubHelpers
   include Rack::Test::Methods

--- a/spec/acceptance/app_spec.rb
+++ b/spec/acceptance/app_spec.rb
@@ -5,6 +5,7 @@ require_relative "../../app"
 ENV["RACK_ENV"] = "test"
 
 describe GovukDependencies do
+  include StubHelpers
   include Rack::Test::Methods
   def app
     described_class
@@ -21,12 +22,9 @@ describe GovukDependencies do
   context "Dashboard" do
     context "given open pull requests" do
       before do
-        stub_request(:get, "https://api.github.com/search/issues?per_page=100&q=is:pr+user:alphagov+state:open+author:app/dependabot+author:app/dependabot-preview+review:approved")
-          .to_return(body: '{ "total_count": 0, "incomplete_results": false, "items": [] }', headers: { "Content-Type" => "application/json" })
-        stub_request(:get, "https://api.github.com/search/issues?per_page=100&q=is:pr+user:alphagov+state:open+author:app/dependabot+author:app/dependabot-preview+review:required")
-          .to_return(body: File.read("spec/fixtures/pull_requests.json"), headers: { "Content-Type" => "application/json" })
-        stub_request(:get, "https://api.github.com/search/issues?per_page=100&q=is:pr+user:alphagov+state:open+author:app/dependabot+author:app/dependabot-preview+review:changes_requested")
-          .to_return(body: '{ "total_count": 0, "incomplete_results": false, "items": [] }', headers: { "Content-Type" => "application/json" })
+        stub_github_request(approved_url, no_pull_requests_body)
+        stub_github_request(review_required_url, pull_requests_body)
+        stub_github_request(changes_requested_url, no_pull_requests_body)
       end
 
       context "Pull request by application" do
@@ -76,12 +74,9 @@ describe GovukDependencies do
 
     context "given no open pull requests" do
       before do
-        stub_request(:get, "https://api.github.com/search/issues?per_page=100&q=is:pr+user:alphagov+state:open+author:app/dependabot+author:app/dependabot-preview+review:approved")
-          .to_return(body: '{ "total_count": 0, "incomplete_results": false, "items": [] }', headers: { "Content-Type" => "application/json" })
-        stub_request(:get, "https://api.github.com/search/issues?per_page=100&q=is:pr+user:alphagov+state:open+author:app/dependabot+author:app/dependabot-preview+review:required")
-          .to_return(body: '{ "total_count": 0, "incomplete_results": false, "items": [] }', headers: { "Content-Type" => "application/json" })
-        stub_request(:get, "https://api.github.com/search/issues?per_page=100&q=is:pr+user:alphagov+state:open+author:app/dependabot+author:app/dependabot-preview+review:changes_requested")
-          .to_return(body: '{ "total_count": 0, "incomplete_results": false, "items": [] }', headers: { "Content-Type" => "application/json" })
+        stub_github_request(approved_url, no_pull_requests_body)
+        stub_github_request(review_required_url, no_pull_requests_body)
+        stub_github_request(changes_requested_url, no_pull_requests_body)
       end
 
       context "Pull requests by application" do
@@ -119,12 +114,9 @@ describe GovukDependencies do
 
     context "given pull requests that require review" do
       before do
-        stub_request(:get, "https://api.github.com/search/issues?per_page=100&q=is:pr+user:alphagov+state:open+author:app/dependabot+author:app/dependabot-preview+review:approved")
-          .to_return(body: '{ "total_count": 0, "incomplete_results": false, "items": [] }', headers: { "Content-Type" => "application/json" })
-        stub_request(:get, "https://api.github.com/search/issues?per_page=100&q=is:pr+user:alphagov+state:open+author:app/dependabot+author:app/dependabot-preview+review:required")
-          .to_return(body: File.read("spec/fixtures/pull_requests.json"), headers: { "Content-Type" => "application/json" })
-        stub_request(:get, "https://api.github.com/search/issues?per_page=100&q=is:pr+user:alphagov+state:open+author:app/dependabot+author:app/dependabot-preview+review:changes_requested")
-          .to_return(body: '{ "total_count": 0, "incomplete_results": false, "items": [] }', headers: { "Content-Type" => "application/json" })
+        stub_github_request(approved_url, no_pull_requests_body)
+        stub_github_request(review_required_url, pull_requests_body)
+        stub_github_request(changes_requested_url, no_pull_requests_body)
       end
 
       context "application view" do
@@ -148,12 +140,9 @@ describe GovukDependencies do
 
     context "given open approved pull requests" do
       before do
-        stub_request(:get, "https://api.github.com/search/issues?per_page=100&q=is:pr+user:alphagov+state:open+author:app/dependabot+author:app/dependabot-preview+review:approved")
-          .to_return(body: File.read("spec/fixtures/pull_requests.json"), headers: { "Content-Type" => "application/json" })
-        stub_request(:get, "https://api.github.com/search/issues?per_page=100&q=is:pr+user:alphagov+state:open+author:app/dependabot+author:app/dependabot-preview+review:required")
-          .to_return(body: '{ "total_count": 0, "incomplete_results": false, "items": [] }', headers: { "Content-Type" => "application/json" })
-        stub_request(:get, "https://api.github.com/search/issues?per_page=100&q=is:pr+user:alphagov+state:open+author:app/dependabot+author:app/dependabot-preview+review:changes_requested")
-          .to_return(body: '{ "total_count": 0, "incomplete_results": false, "items": [] }', headers: { "Content-Type" => "application/json" })
+        stub_github_request(approved_url, pull_requests_body)
+        stub_github_request(review_required_url, no_pull_requests_body)
+        stub_github_request(changes_requested_url, no_pull_requests_body)
       end
 
       context "application view" do
@@ -177,12 +166,9 @@ describe GovukDependencies do
 
     context "given pull requests that have changes requested" do
       before do
-        stub_request(:get, "https://api.github.com/search/issues?per_page=100&q=is:pr+user:alphagov+state:open+author:app/dependabot+author:app/dependabot-preview+review:approved")
-          .to_return(body: '{ "total_count": 0, "incomplete_results": false, "items": [] }', headers: { "Content-Type" => "application/json" })
-        stub_request(:get, "https://api.github.com/search/issues?per_page=100&q=is:pr+user:alphagov+state:open+author:app/dependabot+author:app/dependabot-preview+review:required")
-          .to_return(body: '{ "total_count": 0, "incomplete_results": false, "items": [] }', headers: { "Content-Type" => "application/json" })
-        stub_request(:get, "https://api.github.com/search/issues?per_page=100&q=is:pr+user:alphagov+state:open+author:app/dependabot+author:app/dependabot-preview+review:changes_requested")
-          .to_return(body: File.read("spec/fixtures/pull_requests.json"), headers: { "Content-Type" => "application/json" })
+        stub_github_request(approved_url, no_pull_requests_body)
+        stub_github_request(review_required_url, no_pull_requests_body)
+        stub_github_request(changes_requested_url, pull_requests_body)
       end
 
       context "application view" do
@@ -207,12 +193,9 @@ describe GovukDependencies do
 
   context "Slack" do
     before do
-      stub_request(:get, "https://api.github.com/search/issues?per_page=100&q=is:pr+user:alphagov+state:open+author:app/dependabot+author:app/dependabot-preview+review:approved")
-        .to_return(body: '{ "total_count": 0, "incomplete_results": false, "items": [] }', headers: { "Content-Type" => "application/json" })
-      stub_request(:get, "https://api.github.com/search/issues?per_page=100&q=is:pr+user:alphagov+state:open+author:app/dependabot+author:app/dependabot-preview+review:required")
-        .to_return(body: File.read("spec/fixtures/pull_requests.json"), headers: { "Content-Type" => "application/json" })
-      stub_request(:get, "https://api.github.com/search/issues?per_page=100&q=is:pr+user:alphagov+state:open+author:app/dependabot+author:app/dependabot-preview+review:changes_requested")
-        .to_return(body: '{ "total_count": 0, "incomplete_results": false, "items": [] }', headers: { "Content-Type" => "application/json" })
+      stub_github_request(approved_url, no_pull_requests_body)
+      stub_github_request(review_required_url, pull_requests_body)
+      stub_github_request(changes_requested_url, no_pull_requests_body)
       stub_request(:get, "https://docs.publishing.service.gov.uk/apps.json")
         .to_return(
           body: File.read("spec/fixtures/multiple_teams_with_multiple_applications.json"),

--- a/spec/config/initializers/cache_store_spec.rb
+++ b/spec/config/initializers/cache_store_spec.rb
@@ -1,0 +1,45 @@
+RSpec.describe CacheStore do
+  let(:store) { double("store") }
+  let(:cache_store) { CacheStore::Store.new(store) }
+
+  it "Store delegates to the passed object" do
+    expect(store).to receive(:foo)
+    cache_store.foo
+  end
+
+  # dalli/memcached
+  context "when the store defines a 'flush_all' method" do
+    it ".clear delegates 'flush_all' to the passed object" do
+      allow(store).to receive(:flush_all) { true }
+      expect(store).not_to receive(:clear)
+      expect(store).to receive(:flush_all)
+
+      cache_store.clear
+    end
+  end
+
+  context "when the store defines a 'set' method" do
+    it ".write delegates 'set' to the passed object" do
+      allow(store).to receive(:set) { true }
+      expect(store).not_to receive(:write)
+      expect(store).to receive(:set)
+
+      cache_store.write("foo", "bar")
+    end
+  end
+
+  # active_support/filestore
+  context "when the store has no 'flush_all' method" do
+    it ".clear delegates 'clear' to the passed object" do
+      expect(store).to receive(:clear)
+      cache_store.clear
+    end
+  end
+
+  context "when the store has no 'set' method" do
+    it ".write delegates 'write' to the passed object" do
+      expect(store).to receive(:write)
+      cache_store.write("foo", "bar")
+    end
+  end
+end

--- a/spec/gateways/repositories_spec.rb
+++ b/spec/gateways/repositories_spec.rb
@@ -8,13 +8,14 @@ describe Gateways::Repositories do
   end
 
   context "with the alphagov organisation" do
-    let(:repos) do
-      subject.execute.map(&:name)
-    end
+    let(:baseurl) { "https://api.github.com/repos/alphagov" }
+    let(:whitehall) { "#{baseurl}/whitehall" }
+    let(:publishing_api) { "#{baseurl}/publishing-api" }
+    let(:govwifi_admin) { "#{baseurl}/govwifi-admin" }
 
     it "returns only those with a govuk topic" do
-      expect(repos).to include("whitehall", "publishing-api")
-      expect(repos).not_to include("govwifi-admin")
+      expect(subject.govuk_repo_urls).to include(whitehall, publishing_api)
+      expect(subject.govuk_repo_urls).not_to include(govwifi_admin)
     end
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,3 +1,5 @@
+ENV["RACK_ENV"] = "test"
+
 require "climate_control"
 require "webmock/rspec"
 require "rspec"
@@ -17,4 +19,7 @@ end
 
 RSpec.configure do |config|
   config.include StubHelpers
+  config.before(:each) do
+    GovukDependencies.cache.clear
+  end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -6,9 +6,15 @@ require "pry"
 require "vcr"
 require_relative "../lib/loader"
 
+Dir.glob("./spec/support/*.rb").sort.each { |file| require file }
+
 WebMock.disable_net_connect!(allow_localhost: true)
 
 VCR.configure do |config|
   config.cassette_library_dir = "spec/fixtures/vcr_cassettes"
   config.hook_into :webmock
+end
+
+RSpec.configure do |config|
+  config.include StubHelpers
 end

--- a/spec/support/stub_helpers.rb
+++ b/spec/support/stub_helpers.rb
@@ -1,0 +1,30 @@
+module StubHelpers
+  def review_required_url
+    "https://api.github.com/search/issues?per_page=100&q=is:pr+user:alphagov+state:open+author:app/dependabot+author:app/dependabot-preview+review:required"
+  end
+
+  def approved_url
+    "https://api.github.com/search/issues?per_page=100&q=is:pr+user:alphagov+state:open+author:app/dependabot+author:app/dependabot-preview+review:approved"
+  end
+
+  def changes_requested_url
+    "https://api.github.com/search/issues?per_page=100&q=is:pr+user:alphagov+state:open+author:app/dependabot+author:app/dependabot-preview+review:changes_requested"
+  end
+
+  def no_pull_requests_body
+    '{"total_count": 0, "incomplete_results": false, "items": [] }'
+  end
+
+  def pull_requests_body
+    @pull_requests_body ||= File.read("spec/fixtures/pull_requests.json")
+  end
+
+  def stub_github_request(request_url, body)
+    stub_request(:get, request_url)
+      .with(headers: { "Authorization" => "token some_token" })
+      .to_return(
+        body: body,
+        headers: { "Content-Type" => "application/json" },
+      )
+  end
+end


### PR DESCRIPTION
GithubAPI is rate limiting our authenticated requests. See [commit](https://github.com/alphagov/govuk-dependencies/commit/5a7c41a274b3c8b006191fab28487908ee7eda56) for details.

I have added a memcached store, which is well supported by Heroku. The cache is filled via a rake task run by the Heroku scheduler twice a day. 

- [trello](https://trello.com/c/eEIjWmvy/2768-stop-govuk-dependencies-app-being-rate-limited-by-github) 