### PR TITLE
Pass empty array instead of nil for `continuously_deployed_apps`

### DIFF
--- a/lib/use_cases/slack/send_messages.rb
+++ b/lib/use_cases/slack/send_messages.rb
@@ -42,7 +42,7 @@ module UseCases
             channel: applications_by_team.fetch(:team_name),
             message: message_presenter.execute(
               applications_by_team: applications_by_team,
-              continuously_deployed_apps: team.nil? ? nil : team[:continuously_deployed_apps],
+              continuously_deployed_apps: team.nil? ? [] : team[:continuously_deployed_apps],
             ),
           )
         end


### PR DESCRIPTION
Everywhere in the codebase that takes a
`continuously_deployed_apps` parameter expects an array, not a
`nil`.

If I run the `dependapanda_loud` rake task in Heroku, it has been
failing with this message:

```
NoMethodError: undefined method `include?' for nil:NilClass
/app/lib/presenters/slack/full_message.rb:6:in `block in execute'
/app/lib/presenters/slack/full_message.rb:6:in `filter'
/app/lib/presenters/slack/full_message.rb:6:in `execute'
/app/lib/use_cases/slack/send_messages.rb:43:in `block in send_messages'
/app/lib/use_cases/slack/send_messages.rb:39:in `each'
/app/lib/use_cases/slack/send_messages.rb:39:in `send_messages'
/app/lib/use_cases/slack/send_messages.rb:25:in `execute'
/app/dependapanda.rb:15:in `send_full_message'
```

This PR should fix that.

Trello: https://trello.com/c/toNMA1Np/2854-fix-seal-and-dependapanda