### PR TITLE
Use repos.json to access GOV.UK repositories

### DIFF
--- a/lib/gateways/team.rb
+++ b/lib/gateways/team.rb
@@ -4,7 +4,7 @@ require "json"
 module Gateways
   class Team
     def initialize
-      @endpoint = URI("https://docs.publishing.service.gov.uk/apps.json")
+      @endpoint = URI("https://docs.publishing.service.gov.uk/repos.json")
       @default_team_name = "#govuk-developers"
     end
 

--- a/spec/acceptance/app_spec.rb
+++ b/spec/acceptance/app_spec.rb
@@ -45,7 +45,7 @@ describe GovukDependencies do
 
       context "Pull requests by team" do
         before do
-          stub_request(:get, "https://docs.publishing.service.gov.uk/apps.json")
+          stub_request(:get, "https://docs.publishing.service.gov.uk/repos.json")
             .to_return(
               body: File.read("spec/fixtures/multiple_teams_with_multiple_applications.json"),
               headers: { "Content-Type" => "application/json" },
@@ -95,7 +95,7 @@ describe GovukDependencies do
 
       context "Pull requests by team" do
         before do
-          stub_request(:get, "https://docs.publishing.service.gov.uk/apps.json")
+          stub_request(:get, "https://docs.publishing.service.gov.uk/repos.json")
             .to_return(
               body: File.read("spec/fixtures/multiple_teams_with_multiple_applications.json"),
               headers: { "Content-Type" => "application/json" },
@@ -194,7 +194,7 @@ describe GovukDependencies do
       stub_github_request(approved_url, no_pull_requests_body)
       stub_github_request(review_required_url, pull_requests_body)
       stub_github_request(changes_requested_url, no_pull_requests_body)
-      stub_request(:get, "https://docs.publishing.service.gov.uk/apps.json")
+      stub_request(:get, "https://docs.publishing.service.gov.uk/repos.json")
         .to_return(
           body: File.read("spec/fixtures/multiple_teams_with_multiple_applications.json"),
           headers: { "Content-Type" => "application/json" },

--- a/spec/acceptance/dependapanda_spec.rb
+++ b/spec/acceptance/dependapanda_spec.rb
@@ -22,7 +22,7 @@ describe Dependapanda do
     stub_request(:get, "https://api.github.com/search/issues?per_page=100&q=is:pr+user:alphagov+state:open+author:app/dependabot+author:app/dependabot-preview+review:changes_requested")
       .to_return(body: '{ "total_count": 0, "incomplete_results": false, "items": [] }', headers: { "Content-Type" => "application/json" })
 
-    stub_request(:get, "https://docs.publishing.service.gov.uk/apps.json")
+    stub_request(:get, "https://docs.publishing.service.gov.uk/repos.json")
       .to_return(
         body: File.read("spec/fixtures/multiple_teams_with_multiple_applications.json"),
         headers: { "Content-Type" => "application/json" },

--- a/spec/gateways/team_spec.rb
+++ b/spec/gateways/team_spec.rb
@@ -1,7 +1,7 @@
 describe Gateways::Team do
   context "Given no teams" do
     before do
-      stub_request(:get, "https://docs.publishing.service.gov.uk/apps.json")
+      stub_request(:get, "https://docs.publishing.service.gov.uk/repos.json")
         .to_return(body: "[]", headers: { "Content-Type" => "application/json" })
     end
 
@@ -13,7 +13,7 @@ describe Gateways::Team do
 
   context "with no team set and one application" do
     before do
-      stub_request(:get, "https://docs.publishing.service.gov.uk/apps.json")
+      stub_request(:get, "https://docs.publishing.service.gov.uk/repos.json")
         .to_return(
           body: File.read("spec/fixtures/application_with_no_team.json"),
           headers: { "Content-Type" => "application/json" },
@@ -32,7 +32,7 @@ describe Gateways::Team do
   context "Given one team" do
     context "with one application" do
       before do
-        stub_request(:get, "https://docs.publishing.service.gov.uk/apps.json")
+        stub_request(:get, "https://docs.publishing.service.gov.uk/repos.json")
           .to_return(
             body: File.read("spec/fixtures/team_with_one_application.json"),
             headers: { "Content-Type" => "application/json" },
@@ -50,7 +50,7 @@ describe Gateways::Team do
 
     context "with two applications" do
       before do
-        stub_request(:get, "https://docs.publishing.service.gov.uk/apps.json")
+        stub_request(:get, "https://docs.publishing.service.gov.uk/repos.json")
           .to_return(
             body: File.read("spec/fixtures/team_with_two_applications.json"),
             headers: { "Content-Type" => "application/json" },
@@ -69,7 +69,7 @@ describe Gateways::Team do
 
   context "with two teams and multiple applications" do
     before do
-      stub_request(:get, "https://docs.publishing.service.gov.uk/apps.json")
+      stub_request(:get, "https://docs.publishing.service.gov.uk/repos.json")
       .to_return(
         body: File.read("spec/fixtures/multiple_teams_with_multiple_applications.json"),
         headers: { "Content-Type" => "application/json" },


### PR DESCRIPTION
This uses a new endpoint, repos.json [1], to access the GOV.UK
repositories. The apps.json endpoint only returns running applications,
which means that Gems and similar non-running apps aren't including.

Switching to repos.json will include those projects

~~This is open as a draft whilst https://github.com/alphagov/govuk-developer-docs/pull/3481 is open.~~ I also found that I had problems running this due to secondary rate-limiting so it's been hard to test, not sure if there are any tips?

[1]: https://github.com/alphagov/govuk-developer-docs/pull/3481
