### PR TITLE
Fix rate-limiting

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,6 @@ Running this will start your application at [localhost:9292](localhost:9292)
 ### Environment variables
 
 - `GITHUB_TOKEN` - OAuth token generated on GitHub which does not require any special permissions
-  - Used to interact with the GitHub API, although not required it will help avoid limiting
 - `SLACK_WEBHOOK_URL` - The webhook URL for sending Slack messages to
 - `DEPENDAPANDA_SECRET` - Secret token for manually requesting Slack messages
 

--- a/Rakefile
+++ b/Rakefile
@@ -45,19 +45,32 @@ end
 
 desc "Fetch all of the data we need from github in a slow way, and write to the cache"
 task :warm_the_cache do
+  puts "Fetching repos..."
   Rake::Task["fetch_repos"].invoke
-  puts "fetched repos"
-  sleep 10
+  puts "Finished fetching repos."
+
+  puts "Sleeping for 60 seconds to avoid rate-limiting"
+  sleep 60
+
+  puts "Fetching approved PRs..."
   Rake::Task["fetch_approved_pull_requests"].invoke
-  puts "fetched approved PRs"
-  sleep 10
+  puts "Finished fetching approved PRs."
+
+  puts "Sleeping for 60 seconds to avoid rate-limiting"
+  sleep 60
+
+  puts "Fetching changes requested PRs..."
   Rake::Task["fetch_changes_requested_pull_requests"].invoke
-  puts "fetched changes requested PRs"
-  sleep 15
+  puts "Finished fetching changes requested PRs."
+
+  puts "Sleeping for 60 seconds to avoid rate-limiting"
+  sleep 60
+
+  puts "Fetching review required PRs..."
   Rake::Task["fetch_review_required_pull_requests"].invoke
-  puts "fetched review required requested PRs"
+  puts "Finished fetching review required PRs."
 rescue Octokit::Forbidden
-  puts "We've been rate limited. Wait 15 seconds and then hit refresh on the app, or run this task again"
+  puts "We've been rate limited. Wait 60 seconds and then hit refresh on the app, or run this task again"
 end
 
 desc "Flush all data from the memcache server on production. Consider manually refilling the cache with fetch tasks above."

--- a/lib/gateways/pull_request.rb
+++ b/lib/gateways/pull_request.rb
@@ -14,7 +14,7 @@ module Gateways
     end
 
     def approved_pull_requests
-      query = "is:pr user:alphagov state:open author:app/dependabot author:app/dependabot-preview review:approved"
+      query = "is:pr user:alphagov state:open author:app/dependabot review:approved"
       @approved_pull_requests ||= GovukDependencies.cache.fetch("approved") do
         approved = @client.search_issues(query).items
         GovukDependencies.cache.write("approved", approved)
@@ -31,7 +31,7 @@ module Gateways
     end
 
     def changes_requested_pull_requests
-      query = "is:pr user:alphagov state:open author:app/dependabot author:app/dependabot-preview review:changes_requested"
+      query = "is:pr user:alphagov state:open author:app/dependabot review:changes_requested"
       @changes_requested_pull_requests ||= GovukDependencies.cache.fetch("changes_requested") do
         changes_requested = @client.search_issues(query).items
         GovukDependencies.cache.write("changes_requested", changes_requested)
@@ -43,7 +43,7 @@ module Gateways
 
     def fetch_review_required_pull_requests
       @client_without_pagination = GithubClient.new.client(auto_paginate: false)
-      @client_without_pagination.search_issues("is:pr user:alphagov state:open author:app/dependabot author:app/dependabot-preview review:required", per_page: 100)
+      @client_without_pagination.search_issues("is:pr user:alphagov state:open author:app/dependabot review:required", per_page: 100)
 
       last_response = @client_without_pagination.last_response
       return [] if last_response.data.items.empty?

--- a/lib/gateways/pull_request.rb
+++ b/lib/gateways/pull_request.rb
@@ -52,7 +52,7 @@ module Gateways
       pulls << last_response.data.items
 
       until last_response.rels[:next].nil?
-        sleep 10 if (current_page(last_response) % 3).zero?
+        sleep 60 if (current_page(last_response) % 3).zero?
         last_response = last_response.rels[:next].get
         pulls << last_response.data.items
       end

--- a/lib/gateways/pull_request.rb
+++ b/lib/gateways/pull_request.rb
@@ -14,7 +14,7 @@ module Gateways
     end
 
     def approved_pull_requests
-      query = "is:pr user:alphagov state:open author:app/dependabot review:approved"
+      query = "is:pr user:alphagov state:open author:app/dependabot archived:false review:approved"
       @approved_pull_requests ||= GovukDependencies.cache.fetch("approved") do
         approved = @client.search_issues(query).items
         GovukDependencies.cache.write("approved", approved)
@@ -31,7 +31,7 @@ module Gateways
     end
 
     def changes_requested_pull_requests
-      query = "is:pr user:alphagov state:open author:app/dependabot review:changes_requested"
+      query = "is:pr user:alphagov state:open author:app/dependabot archived:false review:changes_requested"
       @changes_requested_pull_requests ||= GovukDependencies.cache.fetch("changes_requested") do
         changes_requested = @client.search_issues(query).items
         GovukDependencies.cache.write("changes_requested", changes_requested)
@@ -43,7 +43,7 @@ module Gateways
 
     def fetch_review_required_pull_requests
       @client_without_pagination = GithubClient.new.client(auto_paginate: false)
-      @client_without_pagination.search_issues("is:pr user:alphagov state:open author:app/dependabot review:required", per_page: 100)
+      @client_without_pagination.search_issues("is:pr user:alphagov state:open author:app/dependabot archived:false review:required", per_page: 100)
 
       last_response = @client_without_pagination.last_response
       return [] if last_response.data.items.empty?

--- a/lib/gateways/pull_request_count.rb
+++ b/lib/gateways/pull_request_count.rb
@@ -5,7 +5,7 @@ module Gateways
     end
 
     def execute
-      @client.search_issues("is:pr user:alphagov author:app/dependabot").total_count
+      @client.search_issues("is:pr user:alphagov state:open author:app/dependabot archived:false").total_count
     end
   end
 end

--- a/lib/gateways/pull_request_count.rb
+++ b/lib/gateways/pull_request_count.rb
@@ -5,7 +5,7 @@ module Gateways
     end
 
     def execute
-      @client.search_issues("is:pr user:alphagov author:app/dependabot author:app/dependabot-preview").total_count
+      @client.search_issues("is:pr user:alphagov author:app/dependabot").total_count
     end
   end
 end

--- a/spec/acceptance/app_spec.rb
+++ b/spec/acceptance/app_spec.rb
@@ -220,7 +220,7 @@ describe GovukDependencies do
 
   context "Stats page" do
     before do
-      stub_request(:get, "https://api.github.com/search/issues?q=is:pr%20user:alphagov%20author:app/dependabot%20author:app/dependabot-preview")
+      stub_request(:get, "https://api.github.com/search/issues?q=is:pr%20user:alphagov%20author:app/dependabot")
         .to_return(body: File.open("spec/fixtures/pull_requests.json"), headers: { "Content-Type" => "application/json" })
     end
 

--- a/spec/acceptance/app_spec.rb
+++ b/spec/acceptance/app_spec.rb
@@ -220,7 +220,7 @@ describe GovukDependencies do
 
   context "Stats page" do
     before do
-      stub_request(:get, "https://api.github.com/search/issues?q=is:pr%20user:alphagov%20author:app/dependabot")
+      stub_request(:get, "https://api.github.com/search/issues?q=is:pr%20user:alphagov%20state:open%20author:app/dependabot%20archived:false")
         .to_return(body: File.open("spec/fixtures/pull_requests.json"), headers: { "Content-Type" => "application/json" })
     end
 

--- a/spec/acceptance/dependapanda_spec.rb
+++ b/spec/acceptance/dependapanda_spec.rb
@@ -15,11 +15,11 @@ describe Dependapanda do
   before do
     ENV["SLACK_WEBHOOK_URL"] = "http://example.com/webhook"
 
-    stub_request(:get, "https://api.github.com/search/issues?per_page=100&q=is:pr+user:alphagov+state:open+author:app/dependabot+review:approved")
+    stub_request(:get, "https://api.github.com/search/issues?per_page=100&q=is:pr+user:alphagov+state:open+author:app/dependabot+archived:false+review:approved")
       .to_return(body: '{ "total_count": 0, "incomplete_results": false, "items": [] }', headers: { "Content-Type" => "application/json" })
-    stub_request(:get, "https://api.github.com/search/issues?per_page=100&q=is:pr+user:alphagov+state:open+author:app/dependabot+review:required")
+    stub_request(:get, "https://api.github.com/search/issues?per_page=100&q=is:pr+user:alphagov+state:open+author:app/dependabot+archived:false+review:required")
       .to_return(body: File.read("spec/fixtures/pull_requests.json"), headers: { "Content-Type" => "application/json" })
-    stub_request(:get, "https://api.github.com/search/issues?per_page=100&q=is:pr+user:alphagov+state:open+author:app/dependabot+review:changes_requested")
+    stub_request(:get, "https://api.github.com/search/issues?per_page=100&q=is:pr+user:alphagov+state:open+author:app/dependabot+archived:false+review:changes_requested")
       .to_return(body: '{ "total_count": 0, "incomplete_results": false, "items": [] }', headers: { "Content-Type" => "application/json" })
 
     stub_request(:get, "https://docs.publishing.service.gov.uk/apps.json")

--- a/spec/acceptance/dependapanda_spec.rb
+++ b/spec/acceptance/dependapanda_spec.rb
@@ -15,11 +15,11 @@ describe Dependapanda do
   before do
     ENV["SLACK_WEBHOOK_URL"] = "http://example.com/webhook"
 
-    stub_request(:get, "https://api.github.com/search/issues?per_page=100&q=is:pr+user:alphagov+state:open+author:app/dependabot+author:app/dependabot-preview+review:approved")
+    stub_request(:get, "https://api.github.com/search/issues?per_page=100&q=is:pr+user:alphagov+state:open+author:app/dependabot+review:approved")
       .to_return(body: '{ "total_count": 0, "incomplete_results": false, "items": [] }', headers: { "Content-Type" => "application/json" })
-    stub_request(:get, "https://api.github.com/search/issues?per_page=100&q=is:pr+user:alphagov+state:open+author:app/dependabot+author:app/dependabot-preview+review:required")
+    stub_request(:get, "https://api.github.com/search/issues?per_page=100&q=is:pr+user:alphagov+state:open+author:app/dependabot+review:required")
       .to_return(body: File.read("spec/fixtures/pull_requests.json"), headers: { "Content-Type" => "application/json" })
-    stub_request(:get, "https://api.github.com/search/issues?per_page=100&q=is:pr+user:alphagov+state:open+author:app/dependabot+author:app/dependabot-preview+review:changes_requested")
+    stub_request(:get, "https://api.github.com/search/issues?per_page=100&q=is:pr+user:alphagov+state:open+author:app/dependabot+review:changes_requested")
       .to_return(body: '{ "total_count": 0, "incomplete_results": false, "items": [] }', headers: { "Content-Type" => "application/json" })
 
     stub_request(:get, "https://docs.publishing.service.gov.uk/apps.json")

--- a/spec/gateways/pull_request_count_spec.rb
+++ b/spec/gateways/pull_request_count_spec.rb
@@ -1,7 +1,7 @@
 describe Gateways::PullRequestCount do
   context "when getting all PRs for dependabot" do
     before do
-      stub_request(:get, "https://api.github.com/search/issues?q=is:pr%20user:alphagov%20author:app/dependabot")
+      stub_request(:get, "https://api.github.com/search/issues?q=is:pr%20user:alphagov%20state:open%20author:app/dependabot%20archived:false")
         .to_return(body: File.open("spec/fixtures/pull_requests.json"), headers: { "Content-Type" => "application/json" })
     end
     it "returns the total count" do

--- a/spec/gateways/pull_request_count_spec.rb
+++ b/spec/gateways/pull_request_count_spec.rb
@@ -1,7 +1,7 @@
 describe Gateways::PullRequestCount do
   context "when getting all PRs for dependabot" do
     before do
-      stub_request(:get, "https://api.github.com/search/issues?q=is:pr%20user:alphagov%20author:app/dependabot%20author:app/dependabot-preview")
+      stub_request(:get, "https://api.github.com/search/issues?q=is:pr%20user:alphagov%20author:app/dependabot")
         .to_return(body: File.open("spec/fixtures/pull_requests.json"), headers: { "Content-Type" => "application/json" })
     end
     it "returns the total count" do

--- a/spec/support/stub_helpers.rb
+++ b/spec/support/stub_helpers.rb
@@ -1,14 +1,14 @@
 module StubHelpers
   def review_required_url
-    "https://api.github.com/search/issues?per_page=100&q=is:pr+user:alphagov+state:open+author:app/dependabot+author:app/dependabot-preview+review:required"
+    "https://api.github.com/search/issues?per_page=100&q=is:pr+user:alphagov+state:open+author:app/dependabot+review:required"
   end
 
   def approved_url
-    "https://api.github.com/search/issues?per_page=100&q=is:pr+user:alphagov+state:open+author:app/dependabot+author:app/dependabot-preview+review:approved"
+    "https://api.github.com/search/issues?per_page=100&q=is:pr+user:alphagov+state:open+author:app/dependabot+review:approved"
   end
 
   def changes_requested_url
-    "https://api.github.com/search/issues?per_page=100&q=is:pr+user:alphagov+state:open+author:app/dependabot+author:app/dependabot-preview+review:changes_requested"
+    "https://api.github.com/search/issues?per_page=100&q=is:pr+user:alphagov+state:open+author:app/dependabot+review:changes_requested"
   end
 
   def no_pull_requests_body

--- a/spec/support/stub_helpers.rb
+++ b/spec/support/stub_helpers.rb
@@ -1,14 +1,14 @@
 module StubHelpers
   def review_required_url
-    "https://api.github.com/search/issues?per_page=100&q=is:pr+user:alphagov+state:open+author:app/dependabot+review:required"
+    "https://api.github.com/search/issues?per_page=100&q=is:pr+user:alphagov+state:open+author:app/dependabot+archived:false+review:required"
   end
 
   def approved_url
-    "https://api.github.com/search/issues?per_page=100&q=is:pr+user:alphagov+state:open+author:app/dependabot+review:approved"
+    "https://api.github.com/search/issues?per_page=100&q=is:pr+user:alphagov+state:open+author:app/dependabot+archived:false+review:approved"
   end
 
   def changes_requested_url
-    "https://api.github.com/search/issues?per_page=100&q=is:pr+user:alphagov+state:open+author:app/dependabot+review:changes_requested"
+    "https://api.github.com/search/issues?per_page=100&q=is:pr+user:alphagov+state:open+author:app/dependabot+archived:false+review:changes_requested"
   end
 
   def no_pull_requests_body


### PR DESCRIPTION
Dependapanda has stopped notifying Slack since the end of March.

It seems like Github is being more aggressive in rate-limiting requests to their API.

This PR attempts to fix this by making API requests more spaced.

[Trello](https://trello.com/c/NpeMpcep/2886-fix-dependapanda-again-5)