### PR TITLE
Remove all Continuous Deployment related logic

### DIFF
--- a/lib/domain/team.rb
+++ b/lib/domain/team.rb
@@ -1,11 +1,10 @@
 module Domain
   class Team
-    attr_reader :team_name, :applications, :continuously_deployed_apps
+    attr_reader :team_name, :applications
 
-    def initialize(team_name:, applications:, continuously_deployed_apps:)
+    def initialize(team_name:, applications:)
       @team_name = team_name
       @applications = applications
-      @continuously_deployed_apps = continuously_deployed_apps
     end
   end
 end

--- a/lib/gateways/team.rb
+++ b/lib/gateways/team.rb
@@ -13,7 +13,6 @@ module Gateways
         Domain::Team.new(
           team_name: (name || default_team_name).tr("#", ""),
           applications: apps.map { |app| app["app_name"] },
-          continuously_deployed_apps: apps.filter { |app| app["continuously_deployed"] }.map { |app| app["app_name"] },
         )
       end
     end

--- a/lib/presenters/slack/full_message.rb
+++ b/lib/presenters/slack/full_message.rb
@@ -1,22 +1,11 @@
 module Presenters
   module Slack
     class FullMessage
-      def execute(applications_by_team:, continuously_deployed_apps: [])
+      def execute(applications_by_team:)
         applications = applications_by_team.fetch(:applications)
-        cd_apps = applications.filter { |app| continuously_deployed_apps.include?(app.fetch(:application_name)) }
-        if pull_requests_count(cd_apps).positive?
-          "#{url_for_team(applications_by_team)} have #{pull_requests_count(cd_apps)} Dependabot PRs open on the following Continuously Deployed apps:
-
-#{body(cd_apps).join(' ')}
-
-And #{pull_requests_count(applications) - pull_requests_count(cd_apps)} Dependabot PRs open on other apps:
-
-#{body(applications - cd_apps).join(' ')}"
-        else
-          "#{url_for_team(applications_by_team)} have #{pull_requests_count(applications)} Dependabot PRs open on the following apps:
+        "#{url_for_team(applications_by_team)} have #{pull_requests_count(applications)} Dependabot PRs open on the following apps:
 
 #{body(applications).join(' ')}"
-        end
       end
 
     private

--- a/lib/presenters/slack/simple_message.rb
+++ b/lib/presenters/slack/simple_message.rb
@@ -1,9 +1,7 @@
 module Presenters
   module Slack
     class SimpleMessage
-      # rubocop:disable Lint/UnusedMethodArgument
-      def execute(applications_by_team:, continuously_deployed_apps:)
-        # rubocop:enable Lint/UnusedMethodArgument
+      def execute(applications_by_team:)
         "You have #{pull_requests_count(applications_by_team)} open Dependabot PR(s) - #{url(applications_by_team)}"
       end
 

--- a/lib/use_cases/distribute/overflow_to_developers_channel.rb
+++ b/lib/use_cases/distribute/overflow_to_developers_channel.rb
@@ -6,24 +6,14 @@ module UseCases
         @overflow_at = overflow_at
 
         redistribution = []
-        continuously_deployed_apps = []
 
         application_prs_by_team.each do |application_prs_for_team|
           redistribution.concat(redistribute(application_prs_for_team[:applications]))
-          if application_prs_for_team[:continuously_deployed_apps]
-            continuously_deployed_apps.concat(application_prs_for_team[:continuously_deployed_apps])
-          end
         end
 
         if redistribution.any?
           ensure_govuk_developers_exists
           govuk_developers_application_prs[:applications].concat(redistribution)
-          redistribution.each do |app|
-            if continuously_deployed_apps.include?(app[:application_name])
-              govuk_developers_application_prs[:continuously_deployed_apps] << app[:application_name]
-            end
-          end
-          # govuk_developers_application_prs[:continuously_deployed_apps].concat("foo")
         end
 
         application_prs_by_team
@@ -35,7 +25,7 @@ module UseCases
 
       def ensure_govuk_developers_exists
         unless govuk_developers_application_prs
-          application_prs_by_team << { team_name: "govuk-developers", applications: [], continuously_deployed_apps: [] }
+          application_prs_by_team << { team_name: "govuk-developers", applications: [] }
         end
       end
 

--- a/lib/use_cases/slack/send_messages.rb
+++ b/lib/use_cases/slack/send_messages.rb
@@ -37,12 +37,10 @@ module UseCases
 
       def send_messages(applications_by_teams)
         applications_by_teams.each do |applications_by_team|
-          team = team_usecase.execute.find { |app| app[:team_name] == applications_by_team.fetch(:team_name) }
           slack_gateway.execute(
             channel: applications_by_team.fetch(:team_name),
             message: message_presenter.execute(
               applications_by_team: applications_by_team,
-              continuously_deployed_apps: team.nil? ? [] : team[:continuously_deployed_apps],
             ),
           )
         end

--- a/lib/use_cases/teams/fetch.rb
+++ b/lib/use_cases/teams/fetch.rb
@@ -12,7 +12,6 @@ module UseCases
           {
             team_name: team.team_name,
             applications: team.applications,
-            continuously_deployed_apps: team.continuously_deployed_apps,
           }
         end
       end

--- a/spec/gateways/team_spec.rb
+++ b/spec/gateways/team_spec.rb
@@ -25,7 +25,6 @@ describe Gateways::Team do
       expect(result.count).to eq(1)
       expect(result.first.team_name).to eq("govuk-developers")
       expect(result.first.applications).to eq(%w[asset-manager])
-      expect(result.first.continuously_deployed_apps).to eq(%w[asset-manager])
     end
   end
 
@@ -44,7 +43,6 @@ describe Gateways::Team do
         expect(result.count).to eq(1)
         expect(result.first.team_name).to eq("govuk-pub-workflow")
         expect(result.first.applications).to eq(%w[asset-manager])
-        expect(result.first.continuously_deployed_apps).to eq(%w[asset-manager])
       end
     end
 
@@ -62,7 +60,6 @@ describe Gateways::Team do
         expect(result.count).to eq(1)
         expect(result.first.team_name).to eq("govuk-platform-health")
         expect(result.first.applications).to eq(%w[asset-manager asset-uploader])
-        expect(result.first.continuously_deployed_apps).to eq(%w[asset-manager])
       end
     end
   end
@@ -82,11 +79,9 @@ describe Gateways::Team do
       expect(result.count).to eq(2)
       expect(result.first.team_name).to eq("govuk-platform-health")
       expect(result.first.applications).to eq(%w[publisher frontend])
-      expect(result.first.continuously_deployed_apps).to eq([])
 
       expect(result.last.team_name).to eq("govuk-searchandnav")
       expect(result.last.applications).to eq(%w[government-frontend])
-      expect(result.last.continuously_deployed_apps).to eq(%w[government-frontend])
     end
   end
 end

--- a/spec/presenters/slack/full_message_spec.rb
+++ b/spec/presenters/slack/full_message_spec.rb
@@ -68,37 +68,5 @@ describe Presenters::Slack::FullMessage do
 
 <https://github.com/alphagov/collections-publisher/pulls?q=is:pr+is:open+label:dependencies|collections-publisher> (1) <https://github.com/alphagov/content-tagger/pulls?q=is:pr+is:open+label:dependencies|content-tagger> (2)')
     end
-
-    it "highlights the continuously deployed apps" do
-      applications_by_team = {
-        team_name: "taxonomy",
-        applications: [
-          {
-            application_name: "collections-publisher",
-            application_url: "https://github.com/alphagov/content-publisher?q=is:pr+is:open+label:dependencies",
-            pull_request_count: 1,
-          },
-          {
-            application_name: "content-tagger",
-            application_url: "https://github.com/alphagov/content-tagger?q=is:pr+is:open+label:dependencies",
-            pull_request_count: 2,
-          },
-        ],
-      }
-      continuously_deployed_apps = %w[collections-publisher]
-
-      result = described_class.new.execute(
-        applications_by_team: applications_by_team,
-        continuously_deployed_apps: continuously_deployed_apps,
-      )
-
-      expect(result).to eq('<https://govuk-dependencies.herokuapp.com/team/taxonomy|taxonomy> have 1 Dependabot PRs open on the following Continuously Deployed apps:
-
-<https://github.com/alphagov/collections-publisher/pulls?q=is:pr+is:open+label:dependencies|collections-publisher> (1)
-
-And 2 Dependabot PRs open on other apps:
-
-<https://github.com/alphagov/content-tagger/pulls?q=is:pr+is:open+label:dependencies|content-tagger> (2)')
-    end
   end
 end

--- a/spec/presenters/slack/simple_message_spec.rb
+++ b/spec/presenters/slack/simple_message_spec.rb
@@ -11,7 +11,7 @@ describe Presenters::Slack::SimpleMessage do
           },
         ],
       }
-      result = described_class.new.execute(applications_by_team: applications_by_team, continuously_deployed_apps: [])
+      result = described_class.new.execute(applications_by_team: applications_by_team)
 
       expect(result).to eq("You have 1 open Dependabot PR(s) - https://govuk-dependencies.herokuapp.com/team/email")
     end

--- a/spec/use_cases/distribute/overflow_to_developers_channel_spec.rb
+++ b/spec/use_cases/distribute/overflow_to_developers_channel_spec.rb
@@ -116,41 +116,4 @@ describe UseCases::Distribute::OverflowToDevelopersChannel do
       expect(overflow_with_dev_team).to have_application_count_for_team(6, "govuk-developers")
     end
   end
-
-  context "with continuously_deployed_apps" do
-    let(:prs_by_team) do
-      [
-        {
-          team_name: "govuk-platform-health",
-          continuously_deployed_apps: %w[whitehall signon support content-publisher],
-          applications:
-            [
-              { application_name: "whitehall", pull_request_count: 5 },
-              { application_name: "signon", pull_request_count: 4 },
-              { application_name: "ckanext-datagovuk", pull_request_count: 3 },
-              { application_name: "collections-publisher", pull_request_count: 2 },
-              { application_name: "content-data-admin", pull_request_count: 1 },
-              { application_name: "content-publisher", pull_request_count: 1 },
-              { application_name: "support", pull_request_count: 1 },
-            ],
-        },
-        {
-          team_name: "govuk-top-team",
-          applications:
-            [
-              { application_name: "not-another-whitehall", pull_request_count: 1 },
-            ],
-        },
-      ]
-    end
-
-    let(:overflow_with_dev_team) do
-      distribute(prs_by_team, 5)
-    end
-
-    it "should retain the continuously_deployed_apps information" do
-      govuk_developers = overflow_with_dev_team.find { |h| h[:team_name] == "govuk-developers" }
-      expect(govuk_developers[:continuously_deployed_apps]).to eq(%w[content-publisher support])
-    end
-  end
 end


### PR DESCRIPTION
The 'continuously deployed apps' logic ([1]) has been broken for a long time.
[1]: https://github.com/alphagov/govuk-dependencies/blob/e245152349ed4428ead26de42ca3e344efd454b5/lib/presenters/slack/full_message.rb#L7-L14

This is because govuk-dependencies tries to read that info from the Developer Docs ([2]).
[2]: https://github.com/alphagov/govuk-dependencies/blob/6d9dfbae47e5e866d676cb2285e0fef93406153d/lib/gateways/team.rb#L7-L16

However, we removed that from the Developer Docs in October 2021 ([3]).
[3]: https://github.com/alphagov/govuk-developer-docs/commit/5f667af9ae00abf969a80408358409eeca97e7b1

Whilst we could in theory retrieve that info from the Release app now ([4]), not
all repos retrieved by govuk-dependencies has a corresponding app in the Release
app, and the JSON endpoints we'd have to query are behind Signon.
[4]: https://release.publishing.service.gov.uk/applications/account-api.json

We did notice the change in govuk-dependencies Slack messages after the move
of data to the Release app, but the technical difficulties above, coupled
with the fact that more and more apps are being migrated to use Continuous
Deployment (and the effort being better spent there) meant we decided not to
fix it.

We kept the code around on the basis it might be useful someday, but we can
always retrieve it from version control if needed, and it currently adds
quite a bit of complexity to the govuk-dependencies app, so is better off
removed.