### PR TITLE
Configure Dependapanda to report PR age

### DIFF
--- a/lib/presenters/slack/full_message.rb
+++ b/lib/presenters/slack/full_message.rb
@@ -3,9 +3,11 @@ module Presenters
     class FullMessage
       def execute(applications_by_team:)
         applications = applications_by_team.fetch(:applications)
+        body_applications = body(applications).join("\n")
+
         "#{url_for_team(applications_by_team)} have #{pull_requests_count(applications)} Dependabot PRs open on the following apps:
 
-#{body(applications).join(' ')}"
+#{body_applications}"
       end
 
     private
@@ -13,7 +15,11 @@ module Presenters
       def body(applications)
         applications.map do |application|
           application_name = application.fetch(:application_name)
-          "<#{url(application_name)}|#{application_name}> (#{application.fetch(:pull_request_count)})"
+          if application.fetch(:pull_request_count) > 1
+            "<#{url(application_name)}|#{application_name}> (#{application.fetch(:pull_request_count)}, oldest one opened #{application.fetch(:oldest_pr)})"
+          else
+            "<#{url(application_name)}|#{application_name}> (#{application.fetch(:pull_request_count)}, opened #{application.fetch(:oldest_pr)})"
+          end
         end
       end
 

--- a/lib/use_cases/group/applications_by_team.rb
+++ b/lib/use_cases/group/applications_by_team.rb
@@ -38,6 +38,7 @@ module UseCases
             application_name: application_name,
             application_url: "https://github.com/alphagov/#{application_name}/pulls?q=is:pr+is:open+label:dependencies",
             pull_request_count: pull_request_for_app.count,
+            oldest_pr: pull_request_for_app.map { |age| age[:open_since] }.max,
           }
         end
       end

--- a/spec/acceptance/dependapanda_spec.rb
+++ b/spec/acceptance/dependapanda_spec.rb
@@ -46,7 +46,7 @@ describe Dependapanda do
   context "Full Message" do
     it "sends all the pull requests in the message" do
       govuk_platform_health_payload = {
-        "payload" => '{"channel":"govuk-platform-health","username":"Dependapanda","icon_emoji":":panda_face:","text":"<https://govuk-dependencies.herokuapp.com/team/govuk-platform-health|govuk-platform-health> have 3 Dependabot PRs open on the following apps:\n\n<https://github.com/alphagov/publisher/pulls?q=is:pr+is:open+label:dependencies|publisher> (2) <https://github.com/alphagov/frontend/pulls?q=is:pr+is:open+label:dependencies|frontend> (1)"}',
+        "payload" => '{"channel":"govuk-platform-health","username":"Dependapanda","icon_emoji":":panda_face:","text":"<https://govuk-dependencies.herokuapp.com/team/govuk-platform-health|govuk-platform-health> have 3 Dependabot PRs open on the following apps:\n\n<https://github.com/alphagov/publisher/pulls?q=is:pr+is:open+label:dependencies|publisher> (2, oldest one opened 611 days ago)\n<https://github.com/alphagov/frontend/pulls?q=is:pr+is:open+label:dependencies|frontend> (1, opened 611 days ago)"}',
       }
 
       described_class.new.send_full_message

--- a/spec/fixtures/pull_requests.json
+++ b/spec/fixtures/pull_requests.json
@@ -48,9 +48,9 @@
       ],
       "milestone": null,
       "comments": 0,
-      "created_at": "2018-01-24T07:41:46Z",
-      "updated_at": "2018-01-24T08:08:41Z",
-      "closed_at": "2018-01-24T08:08:27Z",
+      "created_at": "2018-01-25T07:41:46Z",
+      "updated_at": "2018-01-25T08:08:41Z",
+      "closed_at": "2018-01-25T08:08:27Z",
       "author_association": "NONE",
       "pull_request": {
         "url": "https://api.github.com/repos/alphagov/publisher/pulls/761",

--- a/spec/gateways/pull_request_spec.rb
+++ b/spec/gateways/pull_request_spec.rb
@@ -37,8 +37,8 @@ describe Gateways::PullRequest do
         expect(result[0].application_name).to eq("publisher")
         expect(result[0].url).to eq("https://github.com/alphagov/publisher/pull/761")
         expect(result[0].status).to eq("approved")
-        expect(result[0].opened_at).to eq(Date.parse("2018-01-24"))
-        expect(result[0].open_since).to eq("yesterday")
+        expect(result[0].opened_at).to eq(Date.parse("2018-01-25"))
+        expect(result[0].open_since).to eq("today")
 
         expect(result[1].title).to eq("Bump gds-sso from 13.5.0 to 13.5.1")
         expect(result[1].application_name).to eq("frontend")

--- a/spec/presenters/slack/full_message_spec.rb
+++ b/spec/presenters/slack/full_message_spec.rb
@@ -8,6 +8,7 @@ describe Presenters::Slack::FullMessage do
             application_name: "content-tagger",
             application_url: "https://github.com/alphagov/content-tagger?q=is:pr+is:open+label:dependencies",
             pull_request_count: 1,
+            oldest_pr: "3 days ago",
           },
         ],
       }
@@ -16,7 +17,7 @@ describe Presenters::Slack::FullMessage do
 
       expect(result).to eq('<https://govuk-dependencies.herokuapp.com/team/email|email> have 1 Dependabot PRs open on the following apps:
 
-<https://github.com/alphagov/content-tagger/pulls?q=is:pr+is:open+label:dependencies|content-tagger> (1)')
+<https://github.com/alphagov/content-tagger/pulls?q=is:pr+is:open+label:dependencies|content-tagger> (1, opened 3 days ago)')
     end
   end
 
@@ -29,11 +30,13 @@ describe Presenters::Slack::FullMessage do
             application_name: "collections-publisher",
             application_url: "https://github.com/alphagov/content-publisher?q=is:pr+is:open+label:dependencies",
             pull_request_count: 1,
+            oldest_pr: "3 days ago",
           },
           {
             application_name: "content-tagger",
             application_url: "https://github.com/alphagov/content-tagger?q=is:pr+is:open+label:dependencies",
             pull_request_count: 1,
+            oldest_pr: "3 days ago",
           },
         ],
       }
@@ -42,7 +45,8 @@ describe Presenters::Slack::FullMessage do
 
       expect(result).to eq('<https://govuk-dependencies.herokuapp.com/team/taxonomy|taxonomy> have 2 Dependabot PRs open on the following apps:
 
-<https://github.com/alphagov/collections-publisher/pulls?q=is:pr+is:open+label:dependencies|collections-publisher> (1) <https://github.com/alphagov/content-tagger/pulls?q=is:pr+is:open+label:dependencies|content-tagger> (1)')
+<https://github.com/alphagov/collections-publisher/pulls?q=is:pr+is:open+label:dependencies|collections-publisher> (1, opened 3 days ago)
+<https://github.com/alphagov/content-tagger/pulls?q=is:pr+is:open+label:dependencies|content-tagger> (1, opened 3 days ago)')
     end
 
     it "groups by application" do
@@ -53,11 +57,13 @@ describe Presenters::Slack::FullMessage do
             application_name: "collections-publisher",
             application_url: "https://github.com/alphagov/content-publisher?q=is:pr+is:open+label:dependencies",
             pull_request_count: 1,
+            oldest_pr: "3 days ago",
           },
           {
             application_name: "content-tagger",
             application_url: "https://github.com/alphagov/content-tagger?q=is:pr+is:open+label:dependencies",
             pull_request_count: 2,
+            oldest_pr: "3 days ago",
           },
         ],
       }
@@ -66,7 +72,8 @@ describe Presenters::Slack::FullMessage do
 
       expect(result).to eq('<https://govuk-dependencies.herokuapp.com/team/taxonomy|taxonomy> have 3 Dependabot PRs open on the following apps:
 
-<https://github.com/alphagov/collections-publisher/pulls?q=is:pr+is:open+label:dependencies|collections-publisher> (1) <https://github.com/alphagov/content-tagger/pulls?q=is:pr+is:open+label:dependencies|content-tagger> (2)')
+<https://github.com/alphagov/collections-publisher/pulls?q=is:pr+is:open+label:dependencies|collections-publisher> (1, opened 3 days ago)
+<https://github.com/alphagov/content-tagger/pulls?q=is:pr+is:open+label:dependencies|content-tagger> (2, oldest one opened 3 days ago)')
     end
   end
 end

--- a/spec/use_cases/group/applications_by_team_spec.rb
+++ b/spec/use_cases/group/applications_by_team_spec.rb
@@ -13,6 +13,7 @@ describe UseCases::Group::ApplicationsByTeam do
         application_name: "some-application",
         title: "Some title",
         opened_at: Date.today,
+        open_since: "today",
         url: "http://foo.com",
       }
 
@@ -32,6 +33,7 @@ describe UseCases::Group::ApplicationsByTeam do
               application_url:
               "https://github.com/alphagov/some-application/pulls?q=is:pr+is:open+label:dependencies",
               pull_request_count: 1,
+              oldest_pr: "today",
             },
           ],
         },
@@ -47,6 +49,7 @@ describe UseCases::Group::ApplicationsByTeam do
         application_name: "collections",
         title: "bump x to y",
         opened_at: Date.today,
+        open_since: "today",
         url: "http://foo.com",
       }
 
@@ -59,6 +62,7 @@ describe UseCases::Group::ApplicationsByTeam do
         application_name: "collections-publisher",
         title: "bump x to y",
         opened_at: Date.today,
+        open_since: "today",
         url: "http://foo.com",
       }
 
@@ -78,6 +82,7 @@ describe UseCases::Group::ApplicationsByTeam do
               application_url:
               "https://github.com/alphagov/collections/pulls?q=is:pr+is:open+label:dependencies",
               pull_request_count: 1,
+              oldest_pr: "today",
             },
           ],
         },
@@ -90,6 +95,7 @@ describe UseCases::Group::ApplicationsByTeam do
                       application_url:
                       "https://github.com/alphagov/collections-publisher/pulls?q=is:pr+is:open+label:dependencies",
                       pull_request_count: 1,
+                      oldest_pr: "today",
                     },
                   ],
         },
@@ -105,6 +111,7 @@ describe UseCases::Group::ApplicationsByTeam do
         application_name: "collections",
         title: "bump x to y",
         opened_at: Date.today,
+        open_since: "today",
         url: "http://foo.com",
       }
 
@@ -112,6 +119,7 @@ describe UseCases::Group::ApplicationsByTeam do
         application_name: "collections",
         title: "bump rspec from 1 to 2",
         opened_at: Date.today,
+        open_since: "today",
         url: "http://foo.com",
       }
 
@@ -132,6 +140,7 @@ describe UseCases::Group::ApplicationsByTeam do
               application_url:
               "https://github.com/alphagov/collections/pulls?q=is:pr+is:open+label:dependencies",
               pull_request_count: 2,
+              oldest_pr: "today",
             },
           ],
         },


### PR DESCRIPTION
Made adjustments to Dependapanda, so that when it looks at PRs, it will show
the age of the oldest PR if there are multiple, or when it's only a single PR, it displays its age as well.
Trello card: https://trello.com/c/sWcTRRN1/2951-configure-dependapanda-to-report-on-how-long-prs-have-been-open