### PR TITLE
Check the oldest pr by the date it was opened

### DIFF
--- a/lib/use_cases/group/applications_by_team.rb
+++ b/lib/use_cases/group/applications_by_team.rb
@@ -38,7 +38,7 @@ module UseCases
             application_name: application_name,
             application_url: "https://github.com/alphagov/#{application_name}/pulls?q=is:pr+is:open+label:dependencies",
             pull_request_count: pull_request_for_app.count,
-            oldest_pr: pull_request_for_app.map { |age| age[:open_since] }.max,
+            oldest_pr: pull_request_for_app.min_by { |pr| pr[:opened_at] }[:open_since],
           }
         end
       end

--- a/spec/use_cases/group/applications_by_team_spec.rb
+++ b/spec/use_cases/group/applications_by_team_spec.rb
@@ -9,11 +9,18 @@ describe UseCases::Group::ApplicationsByTeam do
 
   context "Given a pull request and a team" do
     it "associates one pull request to one team" do
-      pull_request = {
+      pull_request_1 = {
         application_name: "some-application",
         title: "Some title",
         opened_at: Date.today,
         open_since: "today",
+        url: "http://foo.com",
+      }
+      pull_request_2 = {
+        application_name: "some-application",
+        title: "Some title",
+        opened_at: Date.parse("2022-08-15 08:00:00"),
+        open_since: "3 days ago",
         url: "http://foo.com",
       }
 
@@ -22,7 +29,7 @@ describe UseCases::Group::ApplicationsByTeam do
         applications: %w[some-application],
       }
 
-      result = subject.execute(pull_requests: [pull_request], teams: [team])
+      result = subject.execute(pull_requests: [pull_request_1, pull_request_2], teams: [team])
       expected_result = [
         {
           team_name: "Some Team",
@@ -32,8 +39,8 @@ describe UseCases::Group::ApplicationsByTeam do
               application_name: "some-application",
               application_url:
               "https://github.com/alphagov/some-application/pulls?q=is:pr+is:open+label:dependencies",
-              pull_request_count: 1,
-              oldest_pr: "today",
+              pull_request_count: 2,
+              oldest_pr: "3 days ago",
             },
           ],
         },


### PR DESCRIPTION
For each application, Dependapanda is specifying when the oldest pr was opened. This information is not correct when an applications has prs opened "today" or "yesterday".