### PR TITLE
Improving Dependapanda message sorting

### DIFF
--- a/lib/use_cases/group/applications_by_team.rb
+++ b/lib/use_cases/group/applications_by_team.rb
@@ -26,7 +26,7 @@ module UseCases
           applications = application_pull_requests(pull_requests)
           {
             team_name: team.nil? ? FALLBACK_TEAM : team[:team_name],
-            applications: applications.sort_by { |app| [-app[:pull_request_count], app[:application_name]] },
+            applications: applications.sort_by { |app| [-app[:opened_at], -app[:pull_request_count], app[:application_name]] },
           }
         end
       end
@@ -39,6 +39,7 @@ module UseCases
             application_url: "https://github.com/alphagov/#{application_name}/pulls?q=is:pr+is:open+label:dependencies",
             pull_request_count: pull_request_for_app.count,
             oldest_pr: pull_request_for_app.min_by { |pr| pr[:opened_at] }[:open_since],
+            opened_at: pull_request_for_app.map { |pr| pr[:opened_at] }.min.to_date.to_s,
           }
         end
       end

--- a/spec/use_cases/group/applications_by_team_spec.rb
+++ b/spec/use_cases/group/applications_by_team_spec.rb
@@ -19,7 +19,7 @@ describe UseCases::Group::ApplicationsByTeam do
       pull_request_2 = {
         application_name: "some-application",
         title: "Some title",
-        opened_at: Date.parse("2022-08-15 08:00:00"),
+        opened_at: Date.parse("2022-08-15"),
         open_since: "3 days ago",
         url: "http://foo.com",
       }
@@ -41,6 +41,7 @@ describe UseCases::Group::ApplicationsByTeam do
               "https://github.com/alphagov/some-application/pulls?q=is:pr+is:open+label:dependencies",
               pull_request_count: 2,
               oldest_pr: "3 days ago",
+              opened_at: "2022-08-15",
             },
           ],
         },
@@ -90,6 +91,7 @@ describe UseCases::Group::ApplicationsByTeam do
               "https://github.com/alphagov/collections/pulls?q=is:pr+is:open+label:dependencies",
               pull_request_count: 1,
               oldest_pr: "today",
+              opened_at: Date.today.to_date.to_s,
             },
           ],
         },
@@ -103,6 +105,7 @@ describe UseCases::Group::ApplicationsByTeam do
                       "https://github.com/alphagov/collections-publisher/pulls?q=is:pr+is:open+label:dependencies",
                       pull_request_count: 1,
                       oldest_pr: "today",
+                      opened_at: Date.today.to_date.to_s,
                     },
                   ],
         },
@@ -148,11 +151,114 @@ describe UseCases::Group::ApplicationsByTeam do
               "https://github.com/alphagov/collections/pulls?q=is:pr+is:open+label:dependencies",
               pull_request_count: 2,
               oldest_pr: "today",
+              opened_at: Date.today.to_date.to_s,
             },
           ],
         },
       ]
 
+      expect(result).to eq(expected_result)
+    end
+  end
+
+  context "Given multiple applications and prs" do
+    it "associates correctly and sorts by age/pr amount/alpha" do
+      pull_request_1 = {
+        application_name: "sheep-counter",
+        title: "Some title",
+        opened_at: Date.today,
+        open_since: "today",
+        url: "http://foo.com",
+      }
+      pull_request_2 = {
+        application_name: "sheep-counter",
+        title: "Some title",
+        opened_at: Date.parse("2022-08-15"),
+        open_since: "3 days ago",
+        url: "http://foo.com",
+      }
+      pull_request_3 = {
+        application_name: "apple-juicer",
+        title: "Some title",
+        opened_at: Date.today,
+        open_since: "today",
+        url: "http://foo.com",
+      }
+      pull_request_4 = {
+        application_name: "potato-cleaner",
+        title: "Some title",
+        opened_at: Date.today,
+        open_since: "today",
+        url: "http://foo.com",
+      }
+      pull_request_5 = {
+        application_name: "potato-cleaner",
+        title: "Some title",
+        opened_at: Date.today,
+        open_since: "today",
+        url: "http://foo.com",
+      }
+      pull_request_6 = {
+        application_name: "potato-cleaner",
+        title: "Some title",
+        opened_at: Date.today,
+        open_since: "today",
+        url: "http://foo.com",
+      }
+      pull_request_7 = {
+        application_name: "banana-peeler",
+        title: "Some title",
+        opened_at: Date.today,
+        open_since: "today",
+        url: "http://foo.com",
+      }
+
+      team = {
+        team_name: "Some Team",
+        applications: %w[sheep-counter apple-juicer potato-cleaner banana-peeler],
+      }
+
+      result = subject.execute(pull_requests: [pull_request_1, pull_request_2, pull_request_3, pull_request_4, pull_request_5, pull_request_6, pull_request_7], teams: [team])
+      expected_result = [
+        {
+          team_name: "Some Team",
+          applications:
+          [
+            {
+              application_name: "sheep-counter",
+              application_url:
+              "https://github.com/alphagov/sheep-counter/pulls?q=is:pr+is:open+label:dependencies",
+              pull_request_count: 2,
+              oldest_pr: "3 days ago",
+              opened_at: "2022-08-15",
+            },
+            {
+              application_name: "potato-cleaner",
+              application_url:
+              "https://github.com/alphagov/potato-cleaner/pulls?q=is:pr+is:open+label:dependencies",
+              pull_request_count: 3,
+              oldest_pr: "today",
+              opened_at: Date.today.to_date.to_s,
+            },
+            {
+              application_name: "apple-juicer",
+              application_url:
+              "https://github.com/alphagov/apple-juicer/pulls?q=is:pr+is:open+label:dependencies",
+              pull_request_count: 1,
+              oldest_pr: "today",
+              opened_at: Date.today.to_date.to_s,
+            },
+            {
+              application_name: "banana-peeler",
+              application_url:
+              "https://github.com/alphagov/banana-peeler/pulls?q=is:pr+is:open+label:dependencies",
+              pull_request_count: 1,
+              oldest_pr: "today",
+              opened_at: Date.today.to_date.to_s,
+            },
+          ],
+        },
+      ]
       expect(result).to eq(expected_result)
     end
   end

--- a/spec/use_cases/slack/send_messages_spec.rb
+++ b/spec/use_cases/slack/send_messages_spec.rb
@@ -53,6 +53,7 @@ describe UseCases::Slack::SendMessages do
             title: "Bump foo 1.2.3 to 4.5.6",
             status: "approved",
             open_since: "yesterday",
+            opened_at: Date.yesterday,
             url: "https://github.com/alphagov/whitehall/123",
           },
         ])
@@ -84,6 +85,7 @@ describe UseCases::Slack::SendMessages do
             title: "Bump foo 1.2.3 to 4.5.6",
             status: "approved",
             open_since: "yesterday",
+            opened_at: Date.yesterday,
             url: "https://github.com/alphagov/whitehall/123",
           },
           {
@@ -91,6 +93,7 @@ describe UseCases::Slack::SendMessages do
             title: "Bump Rails from 4.2.1 to 5.1.0",
             status: "approved",
             open_since: "today",
+            opened_at: Date.yesterday,
             url: "https://github.com/alphagov/whitehall/123",
           },
         ])
@@ -129,6 +132,7 @@ describe UseCases::Slack::SendMessages do
           title: "Bump foo 1.2.3 to 4.5.6",
           status: "approved",
           open_since: "yesterday",
+          opened_at: Date.yesterday,
           url: "https://github.com/alphagov/whitehall/123",
         },
         {
@@ -136,6 +140,7 @@ describe UseCases::Slack::SendMessages do
           title: "Bump Rails from 4.2.1 to 5.1.0",
           status: "approved",
           open_since: "yesterday",
+          opened_at: Date.yesterday,
           url: "https://github.com/alphagov/whitehall/457",
         },
         {
@@ -143,6 +148,7 @@ describe UseCases::Slack::SendMessages do
           title: "Bump Rails from 1.3.4 to 2.0.0",
           status: "approved",
           open_since: "yesterday",
+          opened_at: Date.yesterday,
           url: "https://github.com/alphagov/travel-advice-publisher/123",
         },
       ])
@@ -183,7 +189,8 @@ describe UseCases::Slack::SendMessages do
             application_name: "whitehall",
             title: "Bump foo 1.2.3 to 4.5.6",
             status: "approved",
-            opened_at: "yesterday",
+            opened_at: Date.yesterday,
+            open_since: "yesterday",
             url: "https://github.com/alphagov/whitehall/123",
           },
         ])
@@ -221,13 +228,15 @@ describe UseCases::Slack::SendMessages do
         {
           application_name: "some-application",
           title: "Bump foo 1.2.3 to 4.5.6",
-          opened_at: "yesterday",
+          opened_at: Date.yesterday,
+          open_since: "yesterday",
           url: "https://github.com/alphagov/whitehall/123",
         },
         {
           application_name: "some-other-application",
           title: "Bump foo 1.2.3 to 4.5.6",
           open_since: "yesterday",
+          opened_at: Date.yesterday,
           url: "https://github.com/alphagov/whitehall/123",
         },
       ])


### PR DESCRIPTION
Changed main sorting criterion from open_since to opened_at to make
sure we sort by actual dates, and no mishaps happen from string open_since values.
Applied sorting priority order as oldest pr, followed by number of open prs, followed by alphabetical.
Trello card: https://trello.com/c/lPnjZ77E/2959-improve-ordering-of-dependapanda-slack-message