### PR TITLE
Alert the Platform Reliability team if a channel does not exist

### DIFF
--- a/lib/gateways/slack_message.rb
+++ b/lib/gateways/slack_message.rb
@@ -2,9 +2,15 @@ require "slack/poster"
 
 module Gateways
   class SlackMessage
+    class PostError < RuntimeError
+    end
+
     def execute(message:, channel:)
       slack_poster = Slack::Poster.new(ENV["SLACK_WEBHOOK_URL"], user_options(channel))
-      slack_poster.send_message(message)
+      response = slack_poster.send_message(message)
+      unless response.success?
+        raise PostError, response.body
+      end
     end
 
     def user_options(channel)

--- a/lib/use_cases/slack/send_messages.rb
+++ b/lib/use_cases/slack/send_messages.rb
@@ -37,12 +37,20 @@ module UseCases
 
       def send_messages(applications_by_teams)
         applications_by_teams.each do |applications_by_team|
-          slack_gateway.execute(
-            channel: applications_by_team.fetch(:team_name),
-            message: message_presenter.execute(
-              applications_by_team: applications_by_team,
-            ),
-          )
+          channel = applications_by_team.fetch(:team_name)
+          begin
+            slack_gateway.execute(
+              channel: channel,
+              message: message_presenter.execute(
+                applications_by_team: applications_by_team,
+              ),
+            )
+          rescue Gateways::SlackMessage::PostError => e
+            slack_gateway.execute(
+              channel: "govuk-platform-reliability-team",
+              message: "Couldn't send message to channel \"#{channel}\" (#{e.message.gsub(/_/, ' ')})",
+            )
+          end
         end
       end
 

--- a/spec/acceptance/dependapanda_spec.rb
+++ b/spec/acceptance/dependapanda_spec.rb
@@ -54,4 +54,23 @@ describe Dependapanda do
       expect(a_request(:post, ENV["SLACK_WEBHOOK_URL"]).with(body: govuk_platform_health_payload)).to have_been_made
     end
   end
+
+  context "When the Slack channel does not exist" do
+    it "sends a notification to the govuk-platform-reliability-team channel" do
+      govuk_platform_health_payload = {
+        "payload" => '{"channel":"govuk-platform-reliability-team","username":"Dependapanda","icon_emoji":":panda_face:","text":"Couldn\'t send message to channel \"govuk-platform-health\" (channel not found)"}',
+      }
+
+      stub_request(:post, ENV["SLACK_WEBHOOK_URL"])
+        .with { |req| req.body !~ /govuk-platform-reliability-team/ }
+        .to_return(
+          status: 404,
+          body: "channel_not_found",
+        )
+
+      described_class.new.send_simple_message
+
+      expect(a_request(:post, ENV["SLACK_WEBHOOK_URL"]).with(body: govuk_platform_health_payload)).to have_been_made
+    end
+  end
 end


### PR DESCRIPTION
Made changes so that when Dependapanda executes but gets an error from Slack API because the channel it is trying to post is missing/does not exist, then it notifies the Platform Reliability team, so we get a warning that those reminders will not reach their intended recipients.

Trello card: https://trello.com/c/6u6FCg0L/2977-get-dependapanda-to-alert-if-the-channel-doesnt-exist-3