### PR TITLE
Set value_max_bytes for memcached

### DIFF
--- a/config/initializers/cache_store.rb
+++ b/config/initializers/cache_store.rb
@@ -11,6 +11,7 @@ module CacheStore
           username: ENV["MEMCACHIER_USERNAME"],
           password: ENV["MEMCACHIER_PASSWORD"],
           expires_in: CACHE_EXPIRY,
+          value_max_bytes: 10_485_760,
         }
       )
   end


### PR DESCRIPTION
The Heroku addon has 25MB and the value_max_bytes was only set to 1MB.

https://trello.com/c/RuNUPRbi/3034-fix-dependapanda